### PR TITLE
Add Docker support for API

### DIFF
--- a/.codex/skills/langoose-dev/SKILL.md
+++ b/.codex/skills/langoose-dev/SKILL.md
@@ -45,3 +45,4 @@ Use this skill to stay aligned with the repo's MVP architecture and product inva
 - For API contract synchronization, use [D:\Projects\langoose\.codex\skills\langoose-api-contracts\SKILL.md](D:\Projects\langoose\.codex\skills\langoose-api-contracts\SKILL.md).
 - For study-loop behavior, use [D:\Projects\langoose\.codex\skills\langoose-study-engine\SKILL.md](D:\Projects\langoose\.codex\skills\langoose-study-engine\SKILL.md).
 - For dictionary and CSV import/export rules, use [D:\Projects\langoose\.codex\skills\langoose-dictionary-imports\SKILL.md](D:\Projects\langoose\.codex\skills\langoose-dictionary-imports\SKILL.md).
+- For Docker and Compose setup, use [D:\Projects\langoose\.codex\skills\langoose-docker\SKILL.md](D:\Projects\langoose\.codex\skills\langoose-docker\SKILL.md).

--- a/.codex/skills/langoose-docker/SKILL.md
+++ b/.codex/skills/langoose-docker/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: langoose-docker
+description: Add or maintain Docker support for the Langoose repo. Use when creating Dockerfiles, .dockerignore, Docker Compose files, containerized local dev workflows, image build strategy, healthchecks, or persistence mounts for the ASP.NET Core API and React/Vite frontend.
+---
+
+# Langoose Docker
+
+Read [D:\Projects\langoose\AGENTS.md](D:\Projects\langoose\AGENTS.md) first.
+
+Use this skill when the task involves Docker, Compose, or containerized local development.
+
+## Main Rules
+
+- Containerize the API and web app as separate concerns.
+- Use multi-stage builds for production-style images.
+- Add `.dockerignore` files or root exclusions to keep build contexts small.
+- Preserve the local JSON-backed store by using a mounted volume or explicit data path, not by baking mutable runtime data into the image.
+
+## Langoose-Specific Guidance
+
+- The API currently persists to `App_Data/store.json`. Container setups must treat that data as runtime state.
+- The frontend talks to the API over HTTP, so Compose or env wiring must make the API base URL explicit.
+- Vite dev servers in containers usually need host binding that works outside the container.
+- Keep local-dev ergonomics in mind: fast rebuilds, readable logs, and simple startup commands matter more than premature production complexity.
+
+## Workflow
+
+- Decide whether the task is dev-only containers, production-style images, or both.
+- Inspect `apps/api` and `apps/web` build/run commands before writing Dockerfiles.
+- Add `.dockerignore` alongside Docker support so image contexts do not include `node_modules`, `bin`, `obj`, `.git`, or runtime data.
+- If Compose is used, prefer health-aware dependency wiring instead of blind startup ordering.
+
+## Load Additional Detail Only When Needed
+
+- For Docker and Compose best practices mapped to this repo, read [D:\Projects\langoose\.codex\skills\langoose-docker\references\docker-guidance.md](D:\Projects\langoose\.codex\skills\langoose-docker\references\docker-guidance.md).

--- a/.codex/skills/langoose-docker/agents/openai.yaml
+++ b/.codex/skills/langoose-docker/agents/openai.yaml
@@ -1,0 +1,4 @@
+version: 1
+display_name: Langoose Docker
+short_description: Add and maintain Docker and Compose support for the Langoose repo.
+default_prompt: Use this skill when working on Dockerfiles, docker compose, containerized local development, image build strategy, or persistence mounts for Langoose.

--- a/.codex/skills/langoose-docker/references/docker-guidance.md
+++ b/.codex/skills/langoose-docker/references/docker-guidance.md
@@ -1,0 +1,45 @@
+# Langoose Docker Guidance
+
+## Official Guidance Applied Here
+
+- Docker recommends multi-stage builds to reduce final image size and separate build-time tooling from runtime artifacts.
+- Docker recommends using small trusted base images, excluding unnecessary files with `.dockerignore`, and keeping containers as ephemeral as possible.
+- Docker Compose supports `depends_on` conditions such as `service_healthy`, which is better than assuming dependency readiness from startup order alone.
+- Microsoft Learn's ASP.NET Core Docker guidance uses multi-stage builds for ASP.NET Core apps.
+
+## What That Means For Langoose
+
+- Prefer separate images for:
+  - `apps/api`
+  - `apps/web`
+- For the API, use an SDK image to build/publish and a runtime image to run.
+- For the frontend, decide explicitly between:
+  - a dev-oriented Vite container, or
+  - a production-style static-serving image
+- Do not copy `App_Data` runtime contents into an image as if they were source artifacts.
+- If the API uses the default `App_Data` path in a container, mount that path to preserve data across container recreation.
+- If Compose is used, expose the API and frontend ports explicitly and pass the frontend API base URL through env configuration.
+
+## Recommended Defaults For This Repo
+
+- Use Linux containers unless there is a Windows-specific requirement.
+- Use multi-stage Dockerfiles.
+- Add `.dockerignore` early.
+- Keep one primary concern per container.
+- Prefer explicit healthchecks for the API if another service depends on it.
+- For local development, prioritize bind-mounted source and fast feedback loops only if the workflow stays reliable on Windows.
+
+## Practical Review Checklist
+
+- Does the Dockerfile copy only what it needs, in a cache-friendly order?
+- Is mutable runtime data excluded from the image and persisted by volume or external path?
+- Is the frontend API URL explicit and correct for the container network?
+- If Compose is used, are dependencies health-aware instead of only startup-ordered?
+- Are image contexts excluding `node_modules`, `bin`, `obj`, `.git`, `.vs`, `.local`, and other irrelevant files?
+
+## Official Sources
+
+- Docker: [Building best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
+- Docker: [Multi-stage builds](https://docs.docker.com/build/building/multi-stage/)
+- Docker: [Control startup order in Compose](https://docs.docker.com/compose/how-tos/startup-order/)
+- Microsoft Learn: [Run an ASP.NET Core app in Docker containers](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/docker/building-net-docker-images?view=aspnetcore-10.0)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,4 @@
 - For request/response contract changes across backend and frontend, use the `langoose-api-contracts` skill in `.codex/skills`.
 - For grading, scheduling, and card-selection changes, use the `langoose-study-engine` skill in `.codex/skills`.
 - For CSV, duplicate normalization, and dictionary visibility rules, use the `langoose-dictionary-imports` skill in `.codex/skills`.
+- For Dockerfiles, Compose, containerized local development, and file-store persistence decisions, use the `langoose-docker` skill in `.codex/skills`.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,32 @@ Run backend checks:
 dotnet test tests/Langoose.Api.Tests/Langoose.Api.Tests.csproj /p:RestoreConfigFile=D:\Projects\langoose\apps\api\NuGet.Config
 ```
 
+## Running the backend with Docker
+
+The API can also run in a Linux container with its JSON store mounted as persistent runtime data.
+
+Build and start it from the repo root:
+
+```powershell
+docker compose up --build api
+```
+
+The container publishes the API on:
+
+- `http://localhost:5000`
+
+Useful notes:
+
+- The image is built from `apps/api/Dockerfile`
+- Persistent API data is stored in the named Docker volume `langoose_api_data`
+- Inside the container, the JSON store lives at `/app/data/store.json`
+
+To stop the container:
+
+```powershell
+docker compose down
+```
+
 ## Running the frontend
 
 The frontend lives in `apps/web`.

--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -1,0 +1,8 @@
+.vs/
+bin/
+obj/
+App_Data/
+*.user
+*.suo
+*.rsuser
+.DS_Store

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,24 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY ["Langoose.Api.csproj", "./"]
+COPY ["NuGet.Config", "./"]
+RUN dotnet restore "Langoose.Api.csproj" --configfile NuGet.Config
+
+COPY . .
+RUN dotnet publish "Langoose.Api.csproj" -c Release -o /app/publish --no-restore
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
+WORKDIR /app
+
+ENV ASPNETCORE_URLS=http://+:8080
+ENV Storage__DataDirectory=/app/data
+
+COPY --from=build /app/publish .
+
+RUN mkdir -p /app/data
+
+VOLUME ["/app/data"]
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "Langoose.Api.dll"]

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,17 @@
+services:
+  api:
+    build:
+      context: ./apps/api
+      dockerfile: Dockerfile
+    container_name: langoose-api
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ASPNETCORE_URLS: http://+:8080
+      Storage__DataDirectory: /app/data
+    ports:
+      - "5000:8080"
+    volumes:
+      - langoose_api_data:/app/data
+
+volumes:
+  langoose_api_data:


### PR DESCRIPTION
## Summary
- add Docker support for the ASP.NET API with a multi-stage image and API-scoped .dockerignore
- add a compose entry that runs the API with a persistent volume for the JSON-backed store
- document the Docker workflow and add the related Codex Docker skill guidance

## Verification
- dotnet test tests/Langoose.Api.Tests/Langoose.Api.Tests.csproj /p:RestoreConfigFile=D:\Projects\langoose\apps\api\NuGet.Config
- docker compose build api
- docker compose up -d api
- GET http://localhost:5000/health
- GET http://localhost:5000/
- docker compose down

Closes #7