### PR TITLE
Add web Docker image and local compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,39 @@ To stop the container:
 docker compose down
 ```
 
+## Running the full Docker stack
+
+The repo also includes a local multi-service Docker setup for the web app, API, and PostgreSQL.
+
+Start everything from the repo root:
+
+```powershell
+docker compose up --build
+```
+
+Use `docker compose up` when the images are already current. Use `docker compose up --build` after changing
+Dockerfiles or files that are copied into the images.
+
+The stack publishes:
+
+- web: `http://localhost:5173`
+- api: `http://localhost:5000`
+- postgres: `localhost:5432`
+
+Useful notes:
+
+- The web container is built from `apps/web/Dockerfile`
+- The web container injects `LANGOOSE_API_BASE_URL` at startup so the same image can target different API hosts
+- PostgreSQL is included for local stack completeness and future work, but the current API still uses the JSON-backed file store
+- API runtime data is still persisted in the named volume `langoose_api_data`
+- PostgreSQL data is persisted in the named volume `langoose_postgres_data`
+
+To stop the full stack:
+
+```powershell
+docker compose down
+```
+
 ## Running the frontend
 
 The frontend lives in `apps/web`.

--- a/apps/web/.dockerignore
+++ b/apps/web/.dockerignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.vite/
+.DS_Store
+npm-debug.log*

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+
+COPY ["package.json", "package-lock.json", "./"]
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine AS final
+
+ENV LANGOOSE_API_BASE_URL=http://localhost:5000
+
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY nginx/40-runtime-config.sh /docker-entrypoint.d/40-runtime-config.sh
+COPY --from=build /app/dist /usr/share/nginx/html
+
+RUN chmod +x /docker-entrypoint.d/40-runtime-config.sh
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;700;800&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+    <script src="/config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </head>
   <body>

--- a/apps/web/nginx/40-runtime-config.sh
+++ b/apps/web/nginx/40-runtime-config.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+cat <<EOF >/usr/share/nginx/html/config.js
+window.LANGOOSE_CONFIG = {
+  apiBaseUrl: "${LANGOOSE_API_BASE_URL}"
+};
+EOF

--- a/apps/web/nginx/default.conf
+++ b/apps/web/nginx/default.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,4 +1,4 @@
-﻿export type AuthResponse = {
+export type AuthResponse = {
   userId: string;
   email: string;
   name: string;
@@ -89,7 +89,9 @@ export type ReportIssueRequest = {
   details: string;
 };
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:5000';
+const API_BASE = window.LANGOOSE_CONFIG?.apiBaseUrl
+  ?? import.meta.env.VITE_API_BASE_URL
+  ?? 'http://localhost:5000';
 
 async function request<T>(path: string, options: RequestInit = {}, token?: string): Promise<T> {
   const response = await fetch(`${API_BASE}${path}`, {

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,1 +1,7 @@
-﻿/// <reference types="vite/client" />
+/// <reference types="vite/client" />
+
+interface Window {
+  LANGOOSE_CONFIG?: {
+    apiBaseUrl?: string;
+  };
+}

--- a/compose.yml
+++ b/compose.yml
@@ -13,5 +13,37 @@ services:
     volumes:
       - langoose_api_data:/app/data
 
+  web:
+    build:
+      context: ./apps/web
+      dockerfile: Dockerfile
+    container_name: langoose-web
+    depends_on:
+      api:
+        condition: service_started
+    environment:
+      LANGOOSE_API_BASE_URL: http://localhost:5000
+    ports:
+      - "5173:80"
+
+  postgres:
+    image: postgres:17-alpine
+    container_name: langoose-postgres
+    environment:
+      POSTGRES_DB: langoose
+      POSTGRES_USER: langoose
+      POSTGRES_PASSWORD: langoose
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U langoose -d langoose"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    ports:
+      - "5432:5432"
+    volumes:
+      - langoose_postgres_data:/var/lib/postgresql/data
+
 volumes:
   langoose_api_data:
+  langoose_postgres_data:


### PR DESCRIPTION
## Summary
- add a production-style Docker image for the React web app with nginx runtime config injection
- extend compose to run the web app, API, and PostgreSQL together for local development
- document the full stack workflow and runtime API base URL behavior

## Verification
- npm run build
- docker compose build
- docker compose up -d
- curl http://localhost:5000/health
- curl http://localhost:5000/
- curl http://localhost:5173/
- curl http://localhost:5173/config.js
- docker compose down

Closes #8
Closes #9