### PR TITLE
Add CI checks for backend and frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  backend-build:
+    name: Backend Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore API
+        run: dotnet restore apps/api/Langoose.Api.csproj /p:RestoreConfigFile=${{ github.workspace }}/apps/api/NuGet.Config
+
+      - name: Build API
+        run: dotnet build apps/api/Langoose.Api.csproj --configuration Release --no-restore /p:RestoreConfigFile=${{ github.workspace }}/apps/api/NuGet.Config
+
+  backend-tests:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore tests
+        run: dotnet restore tests/Langoose.Api.Tests/Langoose.Api.Tests.csproj /p:RestoreConfigFile=${{ github.workspace }}/apps/api/NuGet.Config
+
+      - name: Run backend tests
+        run: dotnet test tests/Langoose.Api.Tests/Langoose.Api.Tests.csproj --configuration Release --no-restore /p:RestoreConfigFile=${{ github.workspace }}/apps/api/NuGet.Config
+
+  frontend-build:
+    name: Frontend Build
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: apps/web
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ Run backend checks:
 dotnet test tests/Langoose.Api.Tests/Langoose.Api.Tests.csproj /p:RestoreConfigFile=D:\Projects\langoose\apps\api\NuGet.Config
 ```
 
+## CI checks
+
+GitHub Actions runs these pull-request checks:
+
+- `CI / Backend Build`
+- `CI / Backend Tests`
+- `CI / Frontend Build`
+
+The workflow does not require repository secrets. These check names are intended to stay stable so branch protection
+rules can require them before merge.
+
 ## Running the backend with Docker
 
 The API can also run in a Linux container with its JSON store mounted as persistent runtime data.


### PR DESCRIPTION
## Summary
- add a GitHub Actions CI workflow with stable backend build, backend test, and frontend build jobs
- run the workflow on pull requests, pushes to main, and manual dispatch
- document the intended branch-protection check names and note that no repository secrets are required

## Verification
- dotnet build apps/api/Langoose.Api.csproj --configuration Release /p:RestoreConfigFile=D:\Projects\langoose\apps\api\NuGet.Config
- dotnet test tests/Langoose.Api.Tests/Langoose.Api.Tests.csproj --configuration Release /p:RestoreConfigFile=D:\Projects\langoose\apps\api\NuGet.Config
- npm run build

Closes #5