### PR TITLE
Deploy Railway API from repo root

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -269,7 +269,7 @@ jobs:
           RAILWAY_API_SERVICE: ${{ vars.RAILWAY_API_SERVICE }}
           RAILWAY_ENVIRONMENT: ${{ vars.RAILWAY_ENVIRONMENT }}
         run: >
-          railway up apps/api/src/Langoose.Api
+          railway up
           --ci
           --service "$RAILWAY_API_SERVICE"
           --environment "$RAILWAY_ENVIRONMENT"

--- a/docs/staging-api-railway.md
+++ b/docs/staging-api-railway.md
@@ -99,7 +99,7 @@ For the GitHub-driven deploy orchestration that can run these steps together, us
   successful `CI`, while manual runs can choose lanes explicitly
 - unified workflow scope: it is self-contained and does not depend on the standalone maintenance workflow YAML files
 - required GitHub environment variable for Railway target selection: `RAILWAY_ENVIRONMENT`
-- API deploy path: `railway up apps/api/src/Langoose.Api --ci ...`
+- API deploy path: `railway up --ci ...`
 
 ## Manual Railway Setup
 

--- a/docs/staging-deployment-workflow.md
+++ b/docs/staging-deployment-workflow.md
@@ -95,8 +95,7 @@ Current workflow behavior:
 - checks out the resolved deployment ref
 - installs the Railway CLI
 - runs `railway up` in CI mode against the configured API service in the configured Railway environment
-- deploys `apps/api/src/Langoose.Api` explicitly while keeping the repo root as the archive base so the Railway config
-  file and Dockerfile can continue to use repo-root-relative paths
+- deploys from the repo root so Railway can resolve the existing repo-root-relative config and Dockerfile paths
 
 ### Vercel
 


### PR DESCRIPTION
## Summary
- change the Railway deploy step to run `railway up` from the repo root
- avoid Railway CLI path-prefix indexing failures in the monorepo deploy flow
- align the staging Railway/deployment docs with the corrected command

Refs #41

## Validation
- `git diff --check --cached`
