### PR TITLE
Deploy Vercel web from source

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -298,35 +298,15 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: npm
-          cache-dependency-path: apps/web/package-lock.json
 
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
-
-      - name: Install web dependencies
-        working-directory: apps/web
-        run: npm ci
 
       - name: Pull Vercel environment information
         env:
           VERCEL_ENVIRONMENT: ${{ needs.resolve-context.outputs.target_environment == 'production' && 'production' || 'preview' }}
         working-directory: apps/web
         run: vercel pull --yes --environment="$VERCEL_ENVIRONMENT" --token="$VERCEL_TOKEN"
-
-      - name: Build Vercel artifacts
-        env:
-          TARGET_ENVIRONMENT: ${{ needs.resolve-context.outputs.target_environment }}
-        working-directory: apps/web
-        shell: bash
-        run: |
-          set -eu
-
-          if [ "$TARGET_ENVIRONMENT" = "production" ]; then
-            vercel build --prod --token="$VERCEL_TOKEN"
-          else
-            vercel build --token="$VERCEL_TOKEN"
-          fi
 
       - name: Deploy web to Vercel
         env:
@@ -337,7 +317,7 @@ jobs:
           set -eu
 
           if [ "$TARGET_ENVIRONMENT" = "production" ]; then
-            vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"
+            vercel deploy --prod --yes --token="$VERCEL_TOKEN"
           else
-            vercel deploy --prebuilt --token="$VERCEL_TOKEN"
+            vercel deploy --yes --token="$VERCEL_TOKEN"
           fi

--- a/docs/staging-deployment-workflow.md
+++ b/docs/staging-deployment-workflow.md
@@ -101,8 +101,8 @@ Current workflow behavior:
 
 The workflow deploys the web app through the Vercel CLI from the checked-out workflow commit.
 
-Vercel documents custom CI/CD workflows around `vercel pull`, `vercel build`, and `vercel deploy --prebuilt`, using
-`VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` from CI. Sources:
+Vercel documents custom CI/CD workflows around `vercel pull` and `vercel deploy`, using `VERCEL_TOKEN`,
+`VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` from CI. Sources:
 
 - [Deploying GitHub projects with Vercel](https://vercel.com/docs/deployments/git/vercel-for-github)
 - [Using the Vercel CLI for custom workflows](https://vercel.com/kb/guide/using-vercel-cli-for-custom-workflows)
@@ -111,8 +111,8 @@ Current workflow behavior:
 
 - checks out the workflow commit
 - pulls the target Vercel environment configuration
-- builds the app in GitHub Actions with the Vercel CLI
-- deploys the prebuilt output to Vercel
+- sends the checked-out source to Vercel through the CLI
+- lets Vercel perform the hosted build in its normal environment
 
 ## Recommended Staging Usage
 

--- a/docs/staging-web-vercel.md
+++ b/docs/staging-web-vercel.md
@@ -86,6 +86,15 @@ The GitHub deployment workflow uses:
 That lets the workflow deploy the same commit it checked out for the rest of the environment update, including reruns
 of older successful workflow runs.
 
+Current GitHub workflow path:
+
+1. check out the workflow commit
+2. run `vercel pull`
+3. run `vercel deploy`
+
+That keeps the build in Vercel's normal hosted environment instead of relying on a local `vercel build` step inside
+GitHub Actions.
+
 ## First Hosted Smoke Checks
 
 After the first staging web deploy succeeds, verify:


### PR DESCRIPTION
## Summary
- switch the staging web deploy from local `vercel build --prebuilt` to Vercel's normal source deploy path
- avoid the GitHub Actions local build failure (`spawn sh ENOENT`)
- align the staging deployment docs with the simpler Vercel CLI flow

Refs #41

## Validation
- `git diff --check`
