### PR TITLE
Run Vercel CLI from repo root

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -305,13 +305,11 @@ jobs:
       - name: Pull Vercel environment information
         env:
           VERCEL_ENVIRONMENT: ${{ needs.resolve-context.outputs.target_environment == 'production' && 'production' || 'preview' }}
-        working-directory: apps/web
         run: vercel pull --yes --environment="$VERCEL_ENVIRONMENT" --token="$VERCEL_TOKEN"
 
       - name: Deploy web to Vercel
         env:
           TARGET_ENVIRONMENT: ${{ needs.resolve-context.outputs.target_environment }}
-        working-directory: apps/web
         shell: bash
         run: |
           set -eu

--- a/docs/staging-deployment-workflow.md
+++ b/docs/staging-deployment-workflow.md
@@ -110,8 +110,8 @@ Vercel documents custom CI/CD workflows around `vercel pull` and `vercel deploy`
 Current workflow behavior:
 
 - checks out the workflow commit
-- pulls the target Vercel environment configuration
-- sends the checked-out source to Vercel through the CLI
+- pulls the target Vercel environment configuration from the repo root
+- sends the checked-out source to Vercel through the CLI from the repo root
 - lets Vercel perform the hosted build in its normal environment
 
 ## Recommended Staging Usage

--- a/docs/staging-web-vercel.md
+++ b/docs/staging-web-vercel.md
@@ -89,11 +89,11 @@ of older successful workflow runs.
 Current GitHub workflow path:
 
 1. check out the workflow commit
-2. run `vercel pull`
-3. run `vercel deploy`
+2. run `vercel pull` from the repo root
+3. run `vercel deploy` from the repo root
 
 That keeps the build in Vercel's normal hosted environment instead of relying on a local `vercel build` step inside
-GitHub Actions.
+GitHub Actions, while letting the Vercel project settings apply the configured `apps/web` root directory only once.
 
 ## First Hosted Smoke Checks
 


### PR DESCRIPTION
## Summary
- run the Vercel CLI from the repo root instead of `apps/web`
- avoid doubling the configured Vercel project root into `apps/web/apps/web`
- align the staging deployment docs with the corrected CLI working directory

Refs #41

## Validation
- `git diff --check`
