### PR TITLE
Split CI/CD workflows and optimize staging deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,53 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+
+  changes:
+    name: Changes
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.detect.outputs.app }}
+      backend: ${{ steps.detect.outputs.backend }}
+
+    steps:
+      - name: Detect deploy-relevant changes
+        id: detect
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const comparison = await github.rest.repos.compareCommitsWithBasehead({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              basehead: `${context.payload.before}...${context.payload.after}`
+            });
+
+            const files = comparison.data.files.map(f => f.filename);
+            const backend = files.some(f => f.startsWith('apps/api/'));
+            const frontend = files.some(f => f.startsWith('apps/web/'));
+
+            core.setOutput('app', (backend || frontend) ? 'true' : 'false');
+            core.setOutput('backend', backend ? 'true' : 'false');
+
+  deploy-staging:
+    name: Deploy Staging
+    needs:
+      - ci
+      - changes
+    if: needs.changes.outputs.app == 'true'
+    uses: ./.github/workflows/deploy-environment.yml
+    with:
+      target_environment: staging
+      deploy_api: ${{ needs.changes.outputs.backend == 'true' }}
+    secrets: inherit

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,9 +33,17 @@ jobs:
               basehead: `${context.payload.before}...${context.payload.after}`
             });
 
-            const files = comparison.data.files.map(f => f.filename);
-            const backend = files.some(f => f.startsWith('apps/api/'));
-            const frontend = files.some(f => f.startsWith('apps/web/'));
+            const files = comparison.data.files;
+
+            if (files.length >= 300) {
+              core.info('Compare API returned 300+ files — assuming truncation, deploying everything');
+              core.setOutput('app', 'true');
+              core.setOutput('backend', 'true');
+              return;
+            }
+
+            const backend = files.some(f => f.filename.startsWith('apps/api/'));
+            const frontend = files.some(f => f.filename.startsWith('apps/web/'));
 
             core.setOutput('app', (backend || frontend) ? 'true' : 'false');
             core.setOutput('backend', backend ? 'true' : 'false');

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,7 @@ jobs:
     outputs:
       app: ${{ steps.detect.outputs.app }}
       backend: ${{ steps.detect.outputs.backend }}
+      frontend: ${{ steps.detect.outputs.frontend }}
 
     steps:
       - name: Detect deploy-relevant changes
@@ -39,6 +40,7 @@ jobs:
               core.info('Compare API returned 300+ files — assuming truncation, deploying everything');
               core.setOutput('app', 'true');
               core.setOutput('backend', 'true');
+              core.setOutput('frontend', 'true');
               return;
             }
 
@@ -47,6 +49,7 @@ jobs:
 
             core.setOutput('app', (backend || frontend) ? 'true' : 'false');
             core.setOutput('backend', backend ? 'true' : 'false');
+            core.setOutput('frontend', frontend ? 'true' : 'false');
 
   deploy-staging:
     name: Deploy Staging
@@ -58,4 +61,5 @@ jobs:
     with:
       target_environment: staging
       deploy_api: ${{ needs.changes.outputs.backend == 'true' }}
+      deploy_web: ${{ needs.changes.outputs.frontend == 'true' }}
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,12 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
+  workflow_call:
   workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -216,3 +218,20 @@ jobs:
       - name: Tear down Compose stack
         if: always()
         run: docker compose --profile e2e down --volumes
+
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - backend-build
+      - backend-unit-tests
+      - backend-integration-tests
+      - frontend-tests
+      - frontend-build
+      - e2e
+
+    steps:
+      - name: Check CI results
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -1,11 +1,19 @@
 name: Deploy Environment
 
 on:
-  workflow_run:
-    workflows:
-      - CI
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      target_environment:
+        required: true
+        type: string
+      deploy_api:
+        required: false
+        type: boolean
+        default: true
+      deploy_web:
+        required: false
+        type: boolean
+        default: true
   workflow_dispatch:
     inputs:
       target_environment:
@@ -27,31 +35,29 @@ on:
         type: boolean
         default: true
 
-run-name: Deploy ${{ github.event_name == 'workflow_run' && 'staging' || inputs.target_environment }}
+run-name: Deploy ${{ inputs.target_environment }}
 
 permissions:
   contents: read
 
 concurrency:
-  group: deploy-${{ github.event_name == 'workflow_run' && 'staging' || inputs.target_environment }}
+  group: deploy-${{ inputs.target_environment }}
   cancel-in-progress: false
 
 jobs:
   resolve-context:
     name: Resolve Deploy Context
     runs-on: ubuntu-latest
-    if: github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main')
     outputs:
-      target_environment: ${{ steps.resolve_manual.outputs.target_environment || steps.resolve_workflow_run.outputs.target_environment }}
-      source_sha: ${{ steps.resolve_manual.outputs.source_sha || steps.resolve_workflow_run.outputs.source_sha }}
-      deploy_api: ${{ steps.resolve_manual.outputs.deploy_api || steps.resolve_workflow_run.outputs.deploy_api }}
-      deploy_web: ${{ steps.resolve_manual.outputs.deploy_web || steps.resolve_workflow_run.outputs.deploy_web }}
-      should_run: ${{ steps.resolve_manual.outputs.should_run || steps.resolve_workflow_run.outputs.should_run }}
+      target_environment: ${{ steps.resolve.outputs.target_environment }}
+      source_sha: ${{ steps.resolve.outputs.source_sha }}
+      deploy_api: ${{ steps.resolve.outputs.deploy_api }}
+      deploy_web: ${{ steps.resolve.outputs.deploy_web }}
+      should_run: ${{ steps.resolve.outputs.should_run }}
 
     steps:
-      - name: Resolve manual dispatch context
-        id: resolve_manual
-        if: github.event_name == 'workflow_dispatch'
+      - name: Resolve deploy context
+        id: resolve
         shell: bash
         run: |
           set -eu
@@ -66,19 +72,6 @@ jobs:
           else
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Resolve successful CI push context
-        id: resolve_workflow_run
-        if: github.event_name == 'workflow_run'
-        shell: bash
-        run: |
-          set -eu
-
-          echo "target_environment=staging" >> "$GITHUB_OUTPUT"
-          echo "source_sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
-          echo "deploy_api=true" >> "$GITHUB_OUTPUT"
-          echo "deploy_web=true" >> "$GITHUB_OUTPUT"
-          echo "should_run=true" >> "$GITHUB_OUTPUT"
 
   validate-config:
     name: Validate Deploy Configuration
@@ -155,7 +148,7 @@ jobs:
     needs:
       - resolve-context
       - validate-config
-    if: needs.resolve-context.outputs.should_run == 'true'
+    if: needs.resolve-context.outputs.deploy_api == 'true'
     environment: ${{ needs.resolve-context.outputs.target_environment }}
 
     steps:
@@ -186,7 +179,7 @@ jobs:
     needs:
       - resolve-context
       - build-dbtool-image
-    if: needs.resolve-context.outputs.should_run == 'true'
+    if: needs.resolve-context.outputs.deploy_api == 'true'
     environment: ${{ needs.resolve-context.outputs.target_environment }}
 
     env:
@@ -215,7 +208,7 @@ jobs:
     needs:
       - resolve-context
       - build-dbtool-image
-    if: needs.resolve-context.outputs.should_run == 'true'
+    if: needs.resolve-context.outputs.deploy_api == 'true'
     environment: ${{ needs.resolve-context.outputs.target_environment }}
 
     env:

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -273,6 +273,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - resolve-context
+      - validate-config
       - deploy-api
     if: always() && needs.resolve-context.outputs.deploy_web == 'true' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     environment: ${{ needs.resolve-context.outputs.target_environment }}

--- a/docs/staging-api-railway.md
+++ b/docs/staging-api-railway.md
@@ -92,11 +92,11 @@ Base-content seeding remains a separate maintenance operation rather than part o
 For the GitHub-driven deploy orchestration that can run these steps together, use:
 
 - workflow: `.github/workflows/deploy-environment.yml`
-- staging trigger: automatic after a successful `CI` run for a push to `main`
+- staging trigger: automatic through `.github/workflows/cd.yml` on push to `main`
 - manual trigger: `workflow_dispatch` with `target_environment=staging|production` and optional `deploy_api` /
   `deploy_web` toggles
-- unified workflow behavior: automatic staging runs always apply migrations and deploy both hosted apps after
-  successful `CI`, while manual runs can choose lanes explicitly
+- unified workflow behavior: automatic staging runs detect which app layers changed and only run migrations and API
+  deploy when backend files change, while manual runs can choose lanes explicitly
 - unified workflow scope: it is self-contained and does not depend on the standalone maintenance workflow YAML files
 - required GitHub environment variable for Railway target selection: `RAILWAY_ENVIRONMENT`
 - API deploy path: `railway up --ci ...`

--- a/docs/staging-deployment-workflow.md
+++ b/docs/staging-deployment-workflow.md
@@ -18,17 +18,19 @@ Related notes:
 
 ## Workflow
 
-The repo now provides one environment-deploy workflow:
+The repo provides two deployment-related workflows:
 
-- workflow: `.github/workflows/deploy-environment.yml`
+- `.github/workflows/cd.yml` — triggers on push to `main`, runs CI then deploys to staging
+- `.github/workflows/deploy-environment.yml` — reusable deploy pipeline, also manually runnable through
+  `workflow_dispatch`
 
-It is:
+The CD workflow calls CI (`.github/workflows/ci.yml`) as a reusable workflow, then calls the deploy workflow for
+staging. This keeps CI and deploy in a single pipeline run for main pushes without creating phantom workflow runs for
+PR CI.
 
-- automatically triggered for `staging` after a successful `CI` run for pushes to `main`
-- manually runnable through `workflow_dispatch`
-
-Automatic staging runs do not require per-step deploy toggles. Manual runs can still choose whether to deploy the API,
-the web app, or both.
+The CD workflow detects which parts of the app changed and passes granular deploy flags. When only frontend files
+change, the deploy skips the DbTool image build, database migrations, and API deploy. Manual runs through
+`deploy-environment.yml` can still choose whether to deploy the API, the web app, or both.
 
 ## What It Can Do
 
@@ -119,8 +121,7 @@ Current workflow behavior:
 For a normal staging release:
 
 1. merge the change into `main`
-2. let `CI` finish successfully for that merge
-3. let `.github/workflows/deploy-environment.yml` run automatically from that successful `CI` run
+2. let `.github/workflows/cd.yml` run CI and then deploy staging automatically
 4. let the workflow always apply auth and app migrations
 5. let the workflow deploy the API
 6. let the workflow deploy the web app
@@ -138,11 +139,12 @@ For manual staging dispatch:
 - choose whether to deploy the API, the web app, or both
 - auth and app migrations still run first
 
-For automatic staging runs after successful `CI` on `main`:
+For automatic staging runs after `CD` on `main`:
 
-- auth and app migrations always run
-- API deploy always runs
-- web deploy always runs
+- changes under `apps/api/` trigger migrations and API deploy
+- changes under `apps/web/` trigger web deploy
+- changes outside `apps/` skip the deploy entirely
+- migrations and DbTool image build only run when backend changes are detected
 
 ## Release Order
 

--- a/docs/staging-setup-runbook.md
+++ b/docs/staging-setup-runbook.md
@@ -25,7 +25,8 @@ The staging environment currently assumes:
 - auth database: `langoose_auth`
 - API hosting: Railway
 - web hosting: Vercel
-- deploy orchestration: GitHub Actions through `.github/workflows/deploy-environment.yml`
+- deploy orchestration: GitHub Actions through `.github/workflows/cd.yml` (automatic staging) and
+  `.github/workflows/deploy-environment.yml` (manual dispatch)
 
 ## One-Time Setup
 


### PR DESCRIPTION
## Summary

- Replace `workflow_run` trigger with `workflow_call` chain: CI → CD → Deploy. Eliminates phantom "Deploy staging (skipped)" runs for every PR CI completion.
- Add change detection in CD: skip DbTool build, migrations, and API deploy for web-only changes; skip deploy entirely for non-app changes (docs, configs).
- Add PR concurrency cancellation to CI: stale runs are cancelled on new pushes.

## Structure

| Workflow | Triggers | Role |
|---|---|---|
| `ci.yml` | `pull_request`, `workflow_call`, `workflow_dispatch` | Build, test, gate |
| `cd.yml` | `push: main` | Calls CI, detects changes, calls deploy |
| `deploy-environment.yml` | `workflow_call`, `workflow_dispatch` | Migrations + deploy |

## Test plan

- [ ] Merge to main with backend changes — full CI + deploy pipeline runs
- [ ] Merge to main with web-only changes — CI runs, deploy skips dbtool/migrations/API, deploys web
- [ ] Merge to main with docs-only changes — CI runs, deploy is skipped entirely
- [ ] PR CI — no phantom deploy workflow runs appear
- [ ] Rapid PR pushes — stale CI runs are cancelled
- [ ] Manual `workflow_dispatch` on Deploy Environment — unchanged behavior

Part of #3.