### PR TITLE
Refresh roadmap for M2-M4 and add enrichment guidance

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git checkout:*)",
+      "Bash(git pull:*)",
+      "Bash(bash scripts/sync-rules.sh to-codex)",
+      "Bash(bash scripts/sync-rules.sh to-claude)",
+      "Bash(bash scripts/sync-rules.sh status)",
+      "Bash(gh milestone:*)",
+      "Bash(gh api:*)",
+      "Bash(echo \"---EXIT:$?\")",
+      "Bash(gh label:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh project:*)"
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,28 @@
 - `chore/...` for maintenance.
 
 
+## Guidance Index
+
+These docs capture detailed rules for specific areas. Read the relevant doc
+when you need detail; update it when a change alters the behavior it describes.
+
+Keep this table in sync when adding or removing docs under `docs/agent/`.
+
+| Doc | Scope |
+|-----|-------|
+| `docs/agent/auth-hosting.md` | Auth cookies, antiforgery, OpenIddict, forwarded headers, hosting |
+| `docs/agent/api-contracts.md` | Request/response models, controller payloads, frontend API types |
+| `docs/agent/dictionary-rules.md` | Dictionary visibility, CSV import/export, duplicate merging |
+| `docs/agent/enrichment-guidance.md` | Async enrichment, shared content layer, enrichment states, LLM provider |
+| `docs/agent/study-engine.md` | Grading, scheduling, card selection, normalization |
+| `docs/agent/dotnet-testing.md` | Test layout, unit vs integration boundaries, test hosts |
+| `docs/agent/efcore-structure.md` | DbContext, migrations, entity config, data project layout |
+| `docs/agent/frontend-guidance.md` | React components, state, effects, TypeScript config |
+| `docs/agent/docker-guidance.md` | Dockerfiles, Compose, containerized dev |
+| `docs/agent/architecture-guidance.md` | Project boundaries, dependency direction |
+| `docs/agent/workflows.md` | Build/test commands, key file locations, validation |
+
+
 ## Skill Index
 
 - Use [langoose-dev](.codex/skills/langoose-dev/SKILL.md) for general repo work or when no narrower skill clearly applies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ Keep this table in sync when adding or removing docs under `docs/agent/`.
 | `docs/agent/auth-hosting.md` | Auth cookies, antiforgery, OpenIddict, forwarded headers, hosting |
 | `docs/agent/api-contracts.md` | Request/response models, controller payloads, frontend API types |
 | `docs/agent/dictionary-rules.md` | Dictionary visibility, CSV import/export, duplicate merging |
+| `docs/agent/enrichment-guidance.md` | Async enrichment, shared content layer, enrichment states, LLM provider |
 | `docs/agent/study-engine.md` | Grading, scheduling, card selection, normalization |
 | `docs/agent/dotnet-testing.md` | Test layout, unit vs integration boundaries, test hosts |
 | `docs/agent/efcore-structure.md` | DbContext, migrations, entity config, data project layout |

--- a/docs/agent/dictionary-rules.md
+++ b/docs/agent/dictionary-rules.md
@@ -21,6 +21,11 @@
 - Export returns only the user's visible custom items in CSV format.
 - Clearing custom data keeps session tokens.
 
+## Enrichment and Visibility
+
+- Custom items require enrichment (AI-generated or user-provided context) before they appear in study cards.
+- See `docs/agent/enrichment-guidance.md` for enrichment states and the shared content layer model.
+
 ## Review Checklist
 
 - Did duplicate normalization still collapse visible entries correctly?

--- a/docs/agent/enrichment-guidance.md
+++ b/docs/agent/enrichment-guidance.md
@@ -1,0 +1,50 @@
+# Langoose Enrichment Guidance
+
+## Purpose
+
+Enrichment is the process of generating example sentences, translation hints, accepted variants,
+and difficulty metadata for dictionary items. It is a shared content layer: AI-generated enrichment
+is reusable across all users, while user-provided custom context is private per user.
+
+## Architecture Decisions
+
+- Enrichment runs as an async background process after a word is added.
+- Shared enrichment: if an item with the same normalized English text is already enriched, reuse that result.
+- User custom context (own sentences, translations) takes priority over AI-generated content and remains private.
+- Provider: best available free-tier LLM (currently Gemini Flash). Abstracted behind an interface to allow swapping.
+- Batch processing for CSV imports and bulk operations, respecting external API rate limits.
+
+## Enrichment States
+
+Each dictionary item has one of three enrichment states that determine study card eligibility:
+
+1. **Custom context provided** — the user supplied their own sentences/translations. Ready for study.
+2. **AI-enriched** — background enrichment completed successfully. Ready for study.
+3. **Pending enrichment** — no custom context and not yet AI-enriched. Hidden from study cards.
+
+The frontend should indicate the current enrichment state to the user.
+
+## Content Generation
+
+For each item, enrichment should produce:
+
+- Natural example sentences with cloze gaps (multiple per item when possible)
+- Russian translation hints for each sentence
+- Accepted answer variants and common collocations
+- Difficulty inference (A1 through B2)
+- Part of speech when determinable
+
+## Rate Limiting and Cost Control
+
+- All external API calls go through a centralized enrichment queue.
+- Processing stays within the provider's free-tier limits.
+- Per-user rate limiting prevents abuse (excessive additions in short periods).
+- Enrichment failures are retried with backoff; items remain in pending state until success.
+
+## Review Checklist
+
+- Does new enrichment content follow the shared-then-private layering?
+- Does the enrichment state correctly gate study card visibility?
+- Are external API calls going through the queue with rate limiting?
+- Does CSV import trigger batch enrichment without exceeding API limits?
+- Is the enrichment provider abstracted behind an interface?

--- a/docs/agent/study-engine.md
+++ b/docs/agent/study-engine.md
@@ -17,6 +17,19 @@
 - Missing articles, inflection variants, and minor typos are intentionally tolerated as `AlmostCorrect`.
 - Phrase similarity can also yield `AlmostCorrect`.
 
+## Enrichment Eligibility
+
+- A card is only eligible for study if its dictionary item has enrichment (AI-generated or user-provided context).
+- Items in pending enrichment state are excluded from card selection.
+- See `docs/agent/enrichment-guidance.md` for enrichment states.
+
+## Scheduling Direction
+
+- The current scheduler uses fixed stability increments and fixed intervals.
+- M3 plans adoption of FSRS (Free Spaced Repetition Scheduler) to replace it.
+- Error analytics should feed back into scheduling: frequently missed words surface more often.
+- All scheduling algorithm decisions and parameters must be documented when changed.
+
 ## Review Checklist
 
 - Did normalization behavior change?
@@ -24,3 +37,4 @@
 - Did scheduler intervals change?
 - Did card balancing between base and custom items change?
 - Did dashboard counts still match the same visibility rules?
+- Did card eligibility still respect enrichment state?

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,11 +7,12 @@ This document is the readable roadmap overview for the project. The live executi
 
 Ship a deployable MVP for Russian speakers learning English that supports:
 
-- real user accounts
+- real user accounts with social login
 - an auth foundation that does not block future native/mobile clients
 - durable persisted data
-- dictionary management
-- study sessions with tolerant grading
+- dictionary management with AI-powered enrichment
+- study sessions with tolerant grading and spaced repetition
+- progress tracking and daily motivation
 - a repeatable deployment path
 
 ## MVP Definition
@@ -20,15 +21,17 @@ The MVP is done when:
 
 - the app is deployable outside local development
 - data persists in PostgreSQL across restarts and redeploys
-- users can sign in, sign out, and keep their own data
+- users can sign in (email/password or Google), sign out, and keep their own data
 - the backend auth model does not depend on a web-only dead end
-- dictionary and study flows work end to end
+- dictionary and study flows work end to end with enriched content
+- custom words are enriched asynchronously and reusable across users
+- study sessions have structure, goals, and visible progress
 - staging deployment exists before production launch
 - core changes are validated through GitHub pull requests and CI
 
 ## Roadmap Phases
 
-### M1 Foundation
+### M1 Foundation (done)
 
 Build the technical base required for a deployable MVP.
 
@@ -43,41 +46,91 @@ Build the technical base required for a deployable MVP.
 
 Complete the core product loop for a returning learner.
 
-- dictionary search, browse, and quick add
-- study sessions backed by persisted progress
-- user-scoped vocabulary and study data
-- progress visibility for daily use
-- web auth and user flows solid in staging and real usage
+**Dictionary and content**
+
+- Expand the base dictionary to 3,000-5,000 entries (A1 through B2, frequency-ordered) via one-time bulk LLM generation
+- Each base entry includes: English term, Russian glosses, example sentences with cloze gaps, difficulty, part of speech, accepted variants
+- Iterate on base content quality through the existing content flagging system
+
+**AI-powered enrichment**
+
+- Async background enrichment for custom words added by users
+- Shared enrichment layer: if a word is already enriched, reuse the result for all users
+- User-provided custom context (own sentences, translations) takes priority and remains private per user
+- Three-state visibility: custom context provided (ready), AI-enriched (ready), pending enrichment (hidden from study cards)
+- Provider: best available free-tier LLM (currently Gemini Flash)
+- Batch processing within external API limits for CSV imports and bulk operations
+- Rate limiting to stay within API quotas and prevent abuse
+
+**Study sessions**
+
+- Structured sessions with defined batch size and end-of-session summary (cards reviewed, accuracy, new words)
+- Option to extend/continue a session beyond the default batch
+- Study sessions backed by persisted progress
+- User-scoped vocabulary and study data
+
+**Progress and motivation**
+
+- Streak counter (consecutive days studied)
+- Daily word goal with progress indicator
+- Progress dashboard with due/new/studied counts
+
+**Auth and access**
+
+- Google OAuth as an external identity provider on top of the existing OpenIddict substrate
+- Web auth and user flows solid in staging and real usage
+
+**Frontend**
+
+- Responsive layout for mobile browsers
+- Dictionary search, browse, and quick add
 
 ### M3 Deployable Beta
 
 Harden the app for broader real-world use.
 
+**Scheduling**
+
+- Adopt FSRS (Free Spaced Repetition Scheduler) to replace the current fixed-interval algorithm
+- Document all implementation decisions and algorithm parameters thoroughly
+- Error analytics: frequently missed words feed back into scheduling and surface more often
+
+**Onboarding**
+
+- Placement test on first login: 20-30 words of increasing difficulty, user marks known ones
+- Known words start with high stability; study begins at the user's actual level
+
+**Content and data**
+
 - CSV import and export on top of the database-backed model
-- duplicate-handling rules preserved in the new persistence model
-- one external identity provider, such as Google, on top of the shared auth substrate
-- staging stability and deployment confidence
-- unresolved MVP gaps closed from testing and user feedback
+- Duplicate-handling rules preserved in the new persistence model
+- Study history export (beyond dictionary CSV)
+
+**Operations**
+
+- Basic admin tooling for reviewing flagged content and managing the base dictionary
+- Improve application logging for staging and production diagnostics
+- Propagate cancellation tokens consistently through API and backend flows
+- Staging stability and deployment confidence
+- Unresolved MVP gaps closed from testing and user feedback
 
 ### M4 Launch
 
 Prepare the app for a first public release.
 
-- production deployment readiness
-- bug fixing and polish
-- basic operational runbooks
-- backup and recovery confidence for persisted data
+- Production deployment readiness
+- Bug fixing and polish
+- Basic operational runbooks
+- Backup and recovery confidence for persisted data
 
-## Current Priorities
+### Post-MVP
 
-The current implementation order is:
+Features to explore after launch, driven by user feedback and usage patterns.
 
-1. Docker-based local development stack
-2. CI checks for backend and frontend
-3. Pull request workflow notes and template
-4. PostgreSQL-backed persistence
-5. OAuth/OIDC-capable authentication foundation
-6. First staging deployment
+- Audio playback / text-to-speech for pronunciation
+- PWA capabilities (offline study, installable app)
+- Advanced learning analytics (retention graphs, learning curves)
+- Additional identity providers
 
 ## Guiding Decisions
 
@@ -88,8 +141,11 @@ These decisions currently shape the roadmap:
 - Docker is the local and deployment packaging layer.
 - PostgreSQL replaces the JSON file store for deployable persistence.
 - The auth foundation should support the web app now without blocking native/mobile later.
-- First-party email/password is the initial login method, but not the final architecture boundary.
+- First-party email/password is the initial login method, with Google OAuth added in M2.
 - Managed hosting is preferred over self-hosting the production database in Docker.
+- Enrichment is a shared content layer: AI-generated content is reusable across users, only user customizations are private.
+- The content flagging system is the primary feedback mechanism for base dictionary quality.
+- All implementation decisions for algorithms (grading, scheduling, enrichment) must be documented.
 
 ## Working Model
 

--- a/scripts/sync-rules.ps1
+++ b/scripts/sync-rules.ps1
@@ -13,15 +13,17 @@ $ErrorActionPreference = "Stop"
 $repoRoot = (git rev-parse --show-toplevel).Trim()
 Set-Location $repoRoot
 
-$agentsMarker = "## Skill Index"
-$claudeMarker = "## Guidance Index"
+$agentsSkillMarker = "## Skill Index"
+$guidanceMarker = "## Guidance Index"
+$claudeSpecificMarker = "## Claude-Specific Notes"
 $agentsPath = Join-Path $repoRoot "AGENTS.md"
 $claudePath = Join-Path $repoRoot "CLAUDE.md"
 
 function Trim-TrailingBlankLines {
     param([string]$Text)
 
-    return ($Text -replace "(\r?\n)+\z", "").TrimEnd()
+    $trimmed = ($Text -replace "(\r?\n)+\z", "").TrimEnd()
+    return ($trimmed -replace "`r`n", "`n")
 }
 
 function Get-AgentsShared {
@@ -30,7 +32,7 @@ function Get-AgentsShared {
     }
 
     $text = Get-Content $agentsPath -Raw
-    $parts = $text -split [regex]::Escape($agentsMarker), 2
+    $parts = $text -split [regex]::Escape($agentsSkillMarker), 2
     return (Trim-TrailingBlankLines $parts[0])
 }
 
@@ -40,7 +42,7 @@ function Get-AgentsSkillIndex {
     }
 
     $text = Get-Content $agentsPath -Raw
-    $index = $text.IndexOf($agentsMarker)
+    $index = $text.IndexOf($agentsSkillMarker)
 
     if ($index -lt 0) {
         return ""
@@ -55,23 +57,12 @@ function Get-ClaudeShared {
     }
 
     $text = Get-Content $claudePath -Raw
-    $parts = $text -split [regex]::Escape($claudeMarker), 2
-    return (Trim-TrailingBlankLines $parts[0])
-}
-
-function Get-ClaudeGuidanceIndex {
-    if (-not (Test-Path $claudePath)) {
-        return ""
-    }
-
-    $text = Get-Content $claudePath -Raw
-    $index = $text.IndexOf($claudeMarker)
-
+    $index = $text.IndexOf($claudeSpecificMarker)
     if ($index -lt 0) {
-        return ""
+        return (Trim-TrailingBlankLines $text)
     }
 
-    return (Trim-TrailingBlankLines $text.Substring($index))
+    return (Trim-TrailingBlankLines $text.Substring(0, $index))
 }
 
 function Write-Utf8NoBom {
@@ -105,16 +96,30 @@ function Sync-ToCodex {
     Audit
 }
 
+function Get-ClaudeSpecific {
+    if (-not (Test-Path $claudePath)) {
+        return ""
+    }
+
+    $text = Get-Content $claudePath -Raw
+    $index = $text.IndexOf($claudeSpecificMarker)
+
+    if ($index -lt 0) {
+        return ""
+    }
+
+    return (Trim-TrailingBlankLines $text.Substring($index))
+}
+
 function Sync-ToClaude {
     $shared = Get-AgentsShared
-    $guidanceIndex = Get-ClaudeGuidanceIndex
+    $claudeSpecific = Get-ClaudeSpecific
 
-    if ([string]::IsNullOrWhiteSpace($guidanceIndex)) {
-        Write-Warning "No Guidance Index found in CLAUDE.md, copying without it"
+    if ([string]::IsNullOrWhiteSpace($claudeSpecific)) {
         Write-Utf8NoBom -Path $claudePath -Content $shared
     }
     else {
-        Write-Utf8NoBom -Path $claudePath -Content ($shared + "`r`n`r`n" + $guidanceIndex)
+        Write-Utf8NoBom -Path $claudePath -Content ($shared + "`r`n`r`n" + $claudeSpecific)
     }
 
     Write-Output "Synced AGENTS.md -> CLAUDE.md"
@@ -202,8 +207,9 @@ function Test-IndexLinks {
 }
 
 function Audit {
-    Test-IndexLinks -Path $agentsPath -Marker $agentsMarker -Label "AGENTS Skill Index"
-    Test-IndexLinks -Path $claudePath -Marker $claudeMarker -Label "CLAUDE Guidance Index"
+    Test-IndexLinks -Path $agentsPath -Marker $guidanceMarker -Label "AGENTS Guidance Index"
+    Test-IndexLinks -Path $agentsPath -Marker $agentsSkillMarker -Label "AGENTS Skill Index"
+    Test-IndexLinks -Path $claudePath -Marker $guidanceMarker -Label "CLAUDE Guidance Index"
 }
 
 function Reconcile {

--- a/scripts/sync-rules.sh
+++ b/scripts/sync-rules.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Sync shared rules between CLAUDE.md and AGENTS.md.
-# AGENTS.md = shared rules + Skill Index (Codex-only section).
-# CLAUDE.md = shared rules + Guidance Index (Claude-Code-only section).
+# Shared rules include the Guidance Index in both files.
+# AGENTS.md also keeps a Codex-only Skill Index appendix.
 #
 # Usage:
 #   scripts/sync-rules.sh to-codex           # CLAUDE.md -> AGENTS.md
@@ -15,27 +15,28 @@
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
-AGENTS_MARKER="## Skill Index"
-CLAUDE_MARKER="## Guidance Index"
+AGENTS_SKILL_MARKER="## Skill Index"
+GUIDANCE_MARKER="## Guidance Index"
+CLAUDE_SPECIFIC_MARKER="## Claude-Specific Notes"
 
 trim_trailing_blank_lines() {
   sed -e :a -e '/^[[:space:]]*$/{$d;N;ba;}'
 }
 
 get_agents_shared() {
-  sed "/^${AGENTS_MARKER}/,\$d" AGENTS.md | trim_trailing_blank_lines
+  sed "/^${AGENTS_SKILL_MARKER}/,\$d" AGENTS.md | trim_trailing_blank_lines
 }
 
 get_agents_skill_index() {
-  sed -n "/^${AGENTS_MARKER}/,\$p" AGENTS.md | trim_trailing_blank_lines
+  sed -n "/^${AGENTS_SKILL_MARKER}/,\$p" AGENTS.md | trim_trailing_blank_lines
 }
 
 get_claude_shared() {
-  sed "/^${CLAUDE_MARKER}/,\$d" CLAUDE.md | trim_trailing_blank_lines
-}
-
-get_claude_guidance_index() {
-  sed -n "/^${CLAUDE_MARKER}/,\$p" CLAUDE.md | trim_trailing_blank_lines
+  if grep -q "^${CLAUDE_SPECIFIC_MARKER}$" CLAUDE.md; then
+    sed "/^${CLAUDE_SPECIFIC_MARKER}/,\$d" CLAUDE.md | trim_trailing_blank_lines
+  else
+    trim_trailing_blank_lines < CLAUDE.md
+  fi
 }
 
 write_agents_from_claude() {
@@ -68,27 +69,32 @@ write_agents_from_claude() {
   audit
 }
 
+get_claude_specific() {
+  if grep -q "^${CLAUDE_SPECIFIC_MARKER}$" CLAUDE.md; then
+    sed -n "/^${CLAUDE_SPECIFIC_MARKER}/,\$p" CLAUDE.md | trim_trailing_blank_lines
+  fi
+}
+
 write_claude_from_agents() {
   if [ ! -f AGENTS.md ]; then
     echo "AGENTS.md not found"
     exit 1
   fi
 
-  local guidance_index=""
+  local claude_specific=""
   if [ -f CLAUDE.md ]; then
-    guidance_index=$(get_claude_guidance_index)
+    claude_specific=$(get_claude_specific)
   fi
 
   local tmp_file
   tmp_file=$(mktemp)
 
-  if [ -z "${guidance_index}" ]; then
-    echo "Warning: no Guidance Index found in CLAUDE.md, copying without it"
+  if [ -z "${claude_specific}" ]; then
     get_agents_shared > "${tmp_file}"
   else
     {
       get_agents_shared
-      printf '\n\n%s\n' "${guidance_index}"
+      printf '\n\n%s\n' "${claude_specific}"
     } > "${tmp_file}"
   fi
 
@@ -169,8 +175,9 @@ audit_index_links() {
 }
 
 audit() {
-  audit_index_links AGENTS.md "${AGENTS_MARKER}" "AGENTS Skill Index"
-  audit_index_links CLAUDE.md "${CLAUDE_MARKER}" "CLAUDE Guidance Index"
+  audit_index_links AGENTS.md "${GUIDANCE_MARKER}" "AGENTS Guidance Index"
+  audit_index_links AGENTS.md "${AGENTS_SKILL_MARKER}" "AGENTS Skill Index"
+  audit_index_links CLAUDE.md "${GUIDANCE_MARKER}" "CLAUDE Guidance Index"
 }
 
 reconcile() {


### PR DESCRIPTION
## Summary

- Rewrites `docs/roadmap.md` with detailed M2, M3, M4, and post-MVP phases based on product discussion
- Adds `docs/agent/enrichment-guidance.md` for the shared content layer architecture (async enrichment, three-state visibility, provider abstraction)
- Updates `dictionary-rules.md` and `study-engine.md` with enrichment visibility rules and FSRS migration direction
- Fixes sync scripts to preserve Claude-specific section on reverse sync and share the Guidance Index in both files
- Creates GitHub issues #56-#66 and adds them to the project board
- Updates milestone descriptions for M2, M3, M4

## Test plan

- [x] `scripts/sync-rules.sh to-codex` passes audit
- [x] `scripts/sync-rules.sh to-claude` preserves Claude-specific section
- [x] `scripts/sync-rules.sh status` reports shared rules in sync
- [x] All guidance index links resolve to existing files