### PR TITLE
Update agent guidance for onion architecture and new domain model

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,11 @@
       "Bash(echo \"---EXIT:$?\")",
       "Bash(gh label:*)",
       "Bash(gh issue:*)",
-      "Bash(gh project:*)"
+      "Bash(gh project:*)",
+      "Skill(what-next)",
+      "Skill(what-next:*)",
+      "Bash(xargs grep:*)",
+      "Bash(git stash:*)"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,10 +90,10 @@ Keep this table in sync when adding or removing docs under `docs/agent/`.
 | Doc | Scope |
 |-----|-------|
 | `docs/agent/architecture-guidance.md` | Onion layers (Domain, Core, Data, Api, Worker), project boundaries, dependency direction |
-| `docs/agent/enrichment-guidance.md` | SharedItem, Gloss, GlossSurfaceForm, async enrichment pipeline, LLM provider, batch processing |
-| `docs/agent/dictionary-rules.md` | SharedItem/UserItem visibility, GlossSurfaceForm dedup, CSV import/export, duplicate merging |
+| `docs/agent/enrichment-guidance.md` | DictionaryEntry, EntryContext, async enrichment pipeline, LLM provider, batch processing |
+| `docs/agent/dictionary-rules.md` | DictionaryEntry/UserDictionaryEntry visibility, form-based dedup, CSV import/export |
 | `docs/agent/study-engine.md` | Sentence-based study cards, UserProgress, answer evaluation via Levenshtein, scheduling |
-| `docs/agent/efcore-structure.md` | Entities, Guid v7, DbContext, migrations, entity config, seeding |
+| `docs/agent/efcore-structure.md` | Entities, Guid v7, composite PKs, DbContext, migrations, entity config, seeding |
 | `docs/agent/api-contracts.md` | DTO mapping pattern, request/response models, controller payloads, frontend API types |
 | `docs/agent/frontend-guidance.md` | React components, state, effects, TypeScript config, API integration |
 | `docs/agent/auth-hosting.md` | Auth cookies, antiforgery, OpenIddict, forwarded headers, hosting |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,8 @@
 - Use one focused branch per issue or tightly related change whenever practical.
 - Keep issue, PR, and project state aligned with the real state of the work.
 - Use squash merge into `main`.
+- When creating sub-issues for an epic, link them as real GitHub sub-issues using the `addSubIssue` GraphQL mutation — not just checklist text in the epic body.
+- Assign the repo owner to every new issue and epic.
 
 ### Branch Naming
 
@@ -87,16 +89,16 @@ Keep this table in sync when adding or removing docs under `docs/agent/`.
 
 | Doc | Scope |
 |-----|-------|
+| `docs/agent/architecture-guidance.md` | Onion layers (Domain, Core, Data, Api, Worker), project boundaries, dependency direction |
+| `docs/agent/enrichment-guidance.md` | SharedItem, Gloss, GlossSurfaceForm, async enrichment pipeline, LLM provider, batch processing |
+| `docs/agent/dictionary-rules.md` | SharedItem/UserItem visibility, GlossSurfaceForm dedup, CSV import/export, duplicate merging |
+| `docs/agent/study-engine.md` | Sentence-based study cards, UserProgress, answer evaluation via Levenshtein, scheduling |
+| `docs/agent/efcore-structure.md` | Entities, Guid v7, DbContext, migrations, entity config, seeding |
+| `docs/agent/api-contracts.md` | DTO mapping pattern, request/response models, controller payloads, frontend API types |
+| `docs/agent/frontend-guidance.md` | React components, state, effects, TypeScript config, API integration |
 | `docs/agent/auth-hosting.md` | Auth cookies, antiforgery, OpenIddict, forwarded headers, hosting |
-| `docs/agent/api-contracts.md` | Request/response models, controller payloads, frontend API types |
-| `docs/agent/dictionary-rules.md` | Dictionary visibility, CSV import/export, duplicate merging |
-| `docs/agent/enrichment-guidance.md` | Async enrichment, shared content layer, enrichment states, LLM provider |
-| `docs/agent/study-engine.md` | Grading, scheduling, card selection, normalization |
 | `docs/agent/dotnet-testing.md` | Test layout, unit vs integration boundaries, test hosts |
-| `docs/agent/efcore-structure.md` | DbContext, migrations, entity config, data project layout |
-| `docs/agent/frontend-guidance.md` | React components, state, effects, TypeScript config |
 | `docs/agent/docker-guidance.md` | Dockerfiles, Compose, containerized dev |
-| `docs/agent/architecture-guidance.md` | Project boundaries, dependency direction |
 | `docs/agent/workflows.md` | Build/test commands, key file locations, validation |
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,8 @@
 - Use one focused branch per issue or tightly related change whenever practical.
 - Keep issue, PR, and project state aligned with the real state of the work.
 - Use squash merge into `main`.
+- When creating sub-issues for an epic, link them as real GitHub sub-issues using the `addSubIssue` GraphQL mutation — not just checklist text in the epic body.
+- Assign the repo owner to every new issue and epic.
 
 ### Branch Naming
 
@@ -87,14 +89,14 @@ Keep this table in sync when adding or removing docs under `docs/agent/`.
 
 | Doc | Scope |
 |-----|-------|
+| `docs/agent/architecture-guidance.md` | Onion layers (Domain, Core, Data, Api, Worker), project boundaries, dependency direction |
+| `docs/agent/enrichment-guidance.md` | SharedItem, Gloss, GlossSurfaceForm, async enrichment pipeline, LLM provider, batch processing |
+| `docs/agent/dictionary-rules.md` | SharedItem/UserItem visibility, GlossSurfaceForm dedup, CSV import/export, duplicate merging |
+| `docs/agent/study-engine.md` | Sentence-based study cards, UserProgress, answer evaluation via Levenshtein, scheduling |
+| `docs/agent/efcore-structure.md` | Entities, Guid v7, DbContext, migrations, entity config, seeding |
+| `docs/agent/api-contracts.md` | DTO mapping pattern, request/response models, controller payloads, frontend API types |
+| `docs/agent/frontend-guidance.md` | React components, state, effects, TypeScript config, API integration |
 | `docs/agent/auth-hosting.md` | Auth cookies, antiforgery, OpenIddict, forwarded headers, hosting |
-| `docs/agent/api-contracts.md` | Request/response models, controller payloads, frontend API types |
-| `docs/agent/dictionary-rules.md` | Dictionary visibility, CSV import/export, duplicate merging |
-| `docs/agent/enrichment-guidance.md` | Async enrichment, shared content layer, enrichment states, LLM provider |
-| `docs/agent/study-engine.md` | Grading, scheduling, card selection, normalization |
 | `docs/agent/dotnet-testing.md` | Test layout, unit vs integration boundaries, test hosts |
-| `docs/agent/efcore-structure.md` | DbContext, migrations, entity config, data project layout |
-| `docs/agent/frontend-guidance.md` | React components, state, effects, TypeScript config |
 | `docs/agent/docker-guidance.md` | Dockerfiles, Compose, containerized dev |
-| `docs/agent/architecture-guidance.md` | Project boundaries, dependency direction |
 | `docs/agent/workflows.md` | Build/test commands, key file locations, validation |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,10 +90,10 @@ Keep this table in sync when adding or removing docs under `docs/agent/`.
 | Doc | Scope |
 |-----|-------|
 | `docs/agent/architecture-guidance.md` | Onion layers (Domain, Core, Data, Api, Worker), project boundaries, dependency direction |
-| `docs/agent/enrichment-guidance.md` | SharedItem, Gloss, GlossSurfaceForm, async enrichment pipeline, LLM provider, batch processing |
-| `docs/agent/dictionary-rules.md` | SharedItem/UserItem visibility, GlossSurfaceForm dedup, CSV import/export, duplicate merging |
+| `docs/agent/enrichment-guidance.md` | DictionaryEntry, EntryContext, async enrichment pipeline, LLM provider, batch processing |
+| `docs/agent/dictionary-rules.md` | DictionaryEntry/UserDictionaryEntry visibility, form-based dedup, CSV import/export |
 | `docs/agent/study-engine.md` | Sentence-based study cards, UserProgress, answer evaluation via Levenshtein, scheduling |
-| `docs/agent/efcore-structure.md` | Entities, Guid v7, DbContext, migrations, entity config, seeding |
+| `docs/agent/efcore-structure.md` | Entities, Guid v7, composite PKs, DbContext, migrations, entity config, seeding |
 | `docs/agent/api-contracts.md` | DTO mapping pattern, request/response models, controller payloads, frontend API types |
 | `docs/agent/frontend-guidance.md` | React components, state, effects, TypeScript config, API integration |
 | `docs/agent/auth-hosting.md` | Auth cookies, antiforgery, OpenIddict, forwarded headers, hosting |

--- a/docs/agent/api-contracts.md
+++ b/docs/agent/api-contracts.md
@@ -2,17 +2,44 @@
 
 ## Main Boundary Files
 
-- Backend API models: `apps/api/src/Langoose.Api/Models/*.cs`
-- Persisted domain types: `apps/api/src/Langoose.Domain/Models/*.cs`
+- Request/response DTOs: `apps/api/src/Langoose.Api/Models/*.cs`
+- Domain entities: `apps/api/src/Langoose.Domain/Models/*.cs`
 - Controllers: `apps/api/src/Langoose.Api/Controllers/*.cs`
 - Frontend client types and calls: `apps/web/src/api.ts`
 
+## DTO Mapping Pattern
+
+Controllers own all DTO ↔ domain model mapping. Services in Core accept and return
+domain models only — they never see request/response DTOs.
+
+```
+Controller receives request DTO
+  → maps to domain model
+  → calls service interface (from Domain)
+  → receives domain model result
+  → maps to response DTO
+  → returns to client
+```
+
+Auth-specific DTOs (SignInRequest, SignUpRequest, etc.) stay in Api/Models since auth
+controllers don't go through Core services.
+
 ## Current Characteristics
 
-- Many request and response DTOs are records.
-- Some API result fields use `JsonStringEnumConverter`.
-- The frontend mirrors several API enums as string unions.
-- The frontend request helper treats `202` and `204` as no-body responses and handles CSV as `text/csv`.
+- Request and response DTOs are records.
+- Enum fields use `JsonStringEnumConverter`.
+- The frontend mirrors API enums as string unions.
+- The frontend request helper treats `202` and `204` as no-body responses and handles
+  CSV as `text/csv`.
+
+## Key Response Shapes
+
+- **Dictionary items**: flat DTO combining SharedItem + UserItem + Gloss data. Includes
+  `enrichmentStatus` for pending/enriched/failed indication.
+- **Study cards**: includes `clozeText`, `sentenceTranslation`, `glosses` (array of
+  canonical forms), `grammarHint`, `difficulty` (per-sentence).
+- **Import response**: includes `pendingEnrichment` count alongside totals.
+- **Study answer result**: includes `exampleSentenceId` for context tracking.
 
 ## Review Checklist
 
@@ -21,3 +48,4 @@
 - Did the frontend type or parsing logic change too?
 - Did enum values remain string-compatible?
 - Did nullable vs optional semantics stay consistent between C# and TypeScript?
+- Are controllers doing DTO ↔ domain mapping (not services)?

--- a/docs/agent/api-contracts.md
+++ b/docs/agent/api-contracts.md
@@ -34,12 +34,14 @@ controllers don't go through Core services.
 
 ## Key Response Shapes
 
-- **Dictionary items**: flat DTO combining SharedItem + UserItem + Gloss data. Includes
-  `enrichmentStatus` for pending/enriched/failed indication.
-- **Study cards**: includes `clozeText`, `sentenceTranslation`, `glosses` (array of
-  canonical forms), `grammarHint`, `difficulty` (per-sentence).
-- **Import response**: includes `pendingEnrichment` count alongside totals.
-- **Study answer result**: includes `exampleSentenceId` for context tracking.
+- **Dictionary items**: flat DTO combining DictionaryEntry + UserDictionaryEntry +
+  EntryTranslation data. Includes `enrichmentStatus`.
+- **Study cards**: includes `cloze` (from EntryContext), sentence translation
+  (from paired context via ContextTranslation), `translations` (from
+  EntryTranslation), `grammarHint` (from DictionaryEntry.GrammarLabel),
+  `difficulty` (from EntryContext).
+- **Import response**: includes `pendingEnrichment` count.
+- **Study answer result**: includes `entryContextId` for context tracking.
 
 ## Review Checklist
 

--- a/docs/agent/architecture-guidance.md
+++ b/docs/agent/architecture-guidance.md
@@ -2,34 +2,115 @@
 
 ## Principle
 
-- Use onion architecture as the mental model.
-- Keep it lightweight.
-- Avoid ceremony-heavy clean architecture unless the repo truly needs it.
+Use onion architecture. Dependencies point inward: Domain has no dependencies,
+everything else depends on Domain directly or transitively.
 
 ```mermaid
 flowchart LR
-  API["Langoose.Api"] --> Domain["Langoose.Domain"]
-  API --> Data["Langoose.Data"]
-  API --> AuthData["Langoose.Auth.Data"]
+  Api["Langoose.Api"] --> Core["Langoose.Core"]
+  Api --> Domain["Langoose.Domain"]
+  Api --> Data["Langoose.Data"]
+  Api --> AuthData["Langoose.Auth.Data"]
+  Worker["Langoose.Worker"] --> Core
+  Worker --> Domain
+  Worker --> Data
+  Core --> Domain
+  Core --> Data
   Data --> Domain
   AuthData --> Domain
-  Tests["apps/api/tests/*"] --> API
-  Tests --> Data
-  Tests --> Domain
+  DbTool["Langoose.DbTool"] --> Data
+  DbTool --> Domain
+  UnitTests["Core.UnitTests"] --> Core
+  UnitTests --> Domain
+  IntTests["Api.IntegrationTests"] --> Api
+  IntTests --> Data
+  IntTests --> Domain
 ```
 
-- Keep dependencies pointing inward toward shared business concepts.
-- Let API own delivery and orchestration, and let data projects own persistence concerns.
-- Add projects only when they create a clearer ownership boundary than the current layout.
+## Layers
 
-## Recommended Shapes
+### Domain (innermost)
 
-- `API + Data` for modest persistence growth.
-- `API + Domain + Data` when core models need a stable shared home outside ASP.NET Core and EF Core.
+`apps/api/src/Langoose.Domain/` — no dependencies.
+
+Contains:
+- **Entities**: `SharedItem`, `Gloss`, `GlossSurfaceForm`, `ExampleSentence`,
+  `UserItem`, `UserCustomSentence`, `UserProgress`, `StudyEvent`, `ContentFlag`,
+  `ImportRecord`
+- **Enums**: `EnrichmentStatus`, `Source`, `UserItemStatus`, `ContentOrigin`,
+  `StudyVerdict`, `FeedbackCode`, `ItemKind`
+- **Constants**: `ExampleQualityScores`, `ReviewDefaults`
+- **Service interfaces**: `IDictionaryService`, `IStudyService`, `IContentService`,
+  `IEnrichmentProvider`
+
+Service interfaces use only domain model types — no DTOs.
+
+### Data
+
+`apps/api/src/Langoose.Data/` — depends on Domain.
+
+Contains:
+- `AppDbContext` with DbSets for all domain entities
+- One `IEntityTypeConfiguration<T>` per entity in `Configurations/`
+- Migrations (fresh per major model rework, auto-applied on startup locally)
+- Seeding (`DatabaseSeeder`, `SeedDataLoader`, `base-store.json`)
+
+### Core
+
+`apps/api/src/Langoose.Core/` — depends on Domain and Data.
+
+Contains:
+- **Services**: `DictionaryService`, `StudyService`, `ContentService`, `EnrichmentService`
+  — implement interfaces from Domain
+- **Providers**: `LocalEnrichmentProvider`, `GeminiEnrichmentProvider`
+  — implement `IEnrichmentProvider` from Domain
+- **Utilities**: `TextNormalizer` — static utility, no interface
+- **Configuration**: settings classes (`EnrichmentSettings`, `GeminiSettings`,
+  `FeaturesSettings`)
+
+Services accept and return domain models. They use `AppDbContext` directly — no
+repository-per-entity abstraction.
+
+### Api (presentation)
+
+`apps/api/src/Langoose.Api/` — depends on Core, Domain, Data, Auth.Data.
+
+Contains:
+- **Controllers**: thin, map request DTOs → domain models → call service → map
+  result → response DTOs
+- **Models**: request/response DTOs (only auth DTOs and API-specific shapes)
+- **Configuration**: `CorsSettings`, `ForwardedHeadersSettings`
+- **Middleware**: `AntiforgeryValidationMiddleware`
+- `Program.cs`: DI composition root
+
+Controllers own all DTO ↔ domain model mapping. Services never see DTOs.
+
+### Worker (presentation)
+
+`apps/api/src/Langoose.Worker/` — depends on Core, Domain, Data.
+
+Contains:
+- **Services**: `EnrichmentBackgroundService` — polls pending items, enriches in
+  batches via `IEnrichmentProvider`
+- `Program.cs`: generic host DI composition root
+- Own `appsettings.json`
+
+Runs as a separate process. Shares the same database.
+
+### Auth.Data
+
+`apps/api/src/Langoose.Auth.Data/` — depends on Domain. Unchanged by this rework.
+Contains `AuthDbContext`, auth entity configs, auth migrations.
+
+### DbTool
+
+`apps/api/src/Langoose.DbTool/` — depends on Data, Domain.
+CLI for applying migrations and seeding in hosted environments.
 
 ## Anti-Goals
 
 - Avoid repository-per-entity by default.
 - Avoid mediator or CQRS by default.
-- Avoid splitting application logic into many thin pass-through layers without a strong reason.
+- Avoid splitting logic into thin pass-through layers without a strong reason.
+- Avoid putting DTOs in Domain — they belong in the presentation layer.
 - Avoid making the code harder to trace than the product complexity requires.

--- a/docs/agent/architecture-guidance.md
+++ b/docs/agent/architecture-guidance.md
@@ -34,11 +34,11 @@ flowchart LR
 `apps/api/src/Langoose.Domain/` — no dependencies.
 
 Contains:
-- **Entities**: `SharedItem`, `Gloss`, `GlossSurfaceForm`, `ExampleSentence`,
-  `UserItem`, `UserCustomSentence`, `UserProgress`, `StudyEvent`, `ContentFlag`,
-  `ImportRecord`
-- **Enums**: `EnrichmentStatus`, `Source`, `UserItemStatus`, `ContentOrigin`,
-  `StudyVerdict`, `FeedbackCode`, `ItemKind`
+- **Entities**: `DictionaryEntry`, `EntryContext`, `UserDictionaryEntry`,
+  `UserEntryContext`, `UserProgress`, `StudyEvent`, `ContentFlag`, `ImportRecord`
+- **Mapping entities**: `EntryTranslation`, `ContextTranslation` (composite PKs)
+- **Enums**: `EnrichmentStatus`, `Source`, `UserEntryStatus`, `ContentOrigin`,
+  `StudyVerdict`, `FeedbackCode`
 - **Constants**: `ExampleQualityScores`, `ReviewDefaults`
 - **Service interfaces**: `IDictionaryService`, `IStudyService`, `IContentService`,
   `IEnrichmentProvider`
@@ -100,7 +100,6 @@ Runs as a separate process. Shares the same database.
 ### Auth.Data
 
 `apps/api/src/Langoose.Auth.Data/` — depends on Domain. Unchanged by this rework.
-Contains `AuthDbContext`, auth entity configs, auth migrations.
 
 ### DbTool
 

--- a/docs/agent/dictionary-rules.md
+++ b/docs/agent/dictionary-rules.md
@@ -12,66 +12,68 @@
 
 The dictionary uses a two-layer model:
 
-- **SharedItem** — enriched English word/phrase concepts. Contains `NormalizedText`,
-  `PartOfSpeech`, `Difficulty`, `IsPublic`, `Source`. Only validated content lives here.
-- **UserItem** — per-user dictionary entries referencing a SharedItem. Contains
-  `RawEnglishText`, `RawGloss`, `Language`, `EnrichmentStatus`, notes, tags, status.
-  `SharedItemId` is nullable (null while pending enrichment).
-- **Gloss** — canonical translations linking SharedItem to a language.
-- **GlossSurfaceForm** — morphological variants pointing to a Gloss for dedup lookups.
+- **DictionaryEntry** — a word or form in any language. Base forms (lemmas) and
+  derived forms (inflections, cases) in the same table, linked by `BaseEntryId`.
+  Only validated/enriched content. `IsPublic` controls visibility.
+- **EntryTranslation** — links base forms across languages (bidirectional).
+- **UserDictionaryEntry** — per-user custom entries referencing a DictionaryEntry.
+  `DictionaryEntryId` is nullable (null while pending enrichment).
 
 ## Visibility Rules
 
-- Users see all public SharedItems (base dictionary) plus their own UserItems that
-  have been enriched (SharedItemId is not null).
-- Pending UserItems (SharedItemId is null) are visible in the dictionary list but
-  excluded from study cards.
-- User-contributed SharedItems have `IsPublic = false` — they don't appear for other
-  users. Admin validation can promote them to public.
+- Users see all public DictionaryEntries (base dictionary) plus their own
+  enriched UserDictionaryEntries (DictionaryEntryId is not null).
+- Pending UserDictionaryEntries (DictionaryEntryId is null) are visible in the
+  dictionary list but excluded from study cards.
+- User-contributed DictionaryEntries have `IsPublic = false` — they don't appear
+  for other users. Admin validation can promote them to public.
 
 ## Quick Add Flow
 
-1. Normalize the English text.
-2. Look up GlossSurfaceForm for the user's gloss in the target language.
-3. If a match is found → Gloss → SharedItem → create UserItem linked to it (Enriched).
-4. If no match → create UserItem with `SharedItemId = null`, `EnrichmentStatus = Pending`.
-   The background worker enriches it later.
-5. Phrase vs word determined automatically from input (contains spaces → phrase).
+1. Look up the user's translation text as a DictionaryEntry form.
+2. If found → follow BaseEntryId → check EntryTranslation for linked entry in
+   the learning language → create UserDictionaryEntry linked to it (Enriched).
+3. If not found → create UserDictionaryEntry with `DictionaryEntryId = null`,
+   `EnrichmentStatus = Pending`. Worker enriches it later.
+4. Phrase vs word determined automatically from input.
 
 ## Duplicate Handling
 
-- Dedup key is GlossSurfaceForm → Gloss → SharedItem. Two users adding the same word
-  with different morphological forms of the same gloss land on the same SharedItem.
-- If a user already has a UserItem for a given SharedItem, the existing UserItem is
-  updated (merged) rather than creating a duplicate.
-- Base vocabulary overlap: if the user adds a word that matches an existing public
-  SharedItem, they get a UserItem linked to it without triggering enrichment.
+- Dedup uses DictionaryEntry form lookup: user types "книгу" → find entry →
+  follow BaseEntryId → "книга" → EntryTranslation → linked base entries.
+- If a user already has a UserDictionaryEntry for a given DictionaryEntry,
+  the existing entry is updated (merged) rather than creating a duplicate.
+- Base vocabulary overlap: if the user adds a word that matches an existing
+  public DictionaryEntry, they get a UserDictionaryEntry linked to it without
+  triggering enrichment.
 
 ## CSV Import
 
-- Required header order: English term, Russian translation(s), Type.
+- Required header order: term, translation(s), type.
 - Optional columns: Notes, Tags.
-- Row-shape errors and malformed input prevent partial import — no half-imported files.
-- Each row follows the quick add flow (GlossSurfaceForm lookup → link or create Pending).
+- Row-shape errors and malformed input prevent partial import.
+- Each row follows the quick add flow.
 - Response includes count of items pending enrichment.
 
 ## CSV Export
 
-- Returns the user's UserItems joined with SharedItem and Gloss data.
-- Only enriched items with SharedItemId are exported.
+- Returns the user's UserDictionaryEntries joined with DictionaryEntry and
+  EntryTranslation data.
+- Only enriched items with DictionaryEntryId are exported.
 
 ## Clear Custom Data
 
-- Deletes all UserItems, UserCustomSentences, and UserProgress for non-public items.
-- Preserves SharedItems (shared content layer).
+- Deletes all UserDictionaryEntries, UserEntryContexts, and UserProgress for
+  non-public items.
+- Preserves DictionaryEntries (shared content layer).
 - Preserves UserProgress for public items (base dictionary study progress).
 - Does not revoke active sessions.
 
 ## Review Checklist
 
-- Does GlossSurfaceForm lookup correctly dedup across morphological variants?
+- Does form lookup correctly dedup across morphological variants?
 - Does CSV validation remain strict and predictable?
 - Does import skip base-overlap and duplicate rows correctly?
-- Does export include SharedItem + Gloss data for enriched items?
-- Does clear-custom-data preserve SharedItems and base dictionary progress?
+- Does export include DictionaryEntry + translation data for enriched items?
+- Does clear-custom-data preserve DictionaryEntries and base dictionary progress?
 - Does clear-custom-data avoid revoking sessions?

--- a/docs/agent/dictionary-rules.md
+++ b/docs/agent/dictionary-rules.md
@@ -2,34 +2,76 @@
 
 ## Main Files
 
-- `apps/api/src/Langoose.Api/Services/DictionaryService.cs`
+- `apps/api/src/Langoose.Core/Services/DictionaryService.cs`
 - `apps/api/src/Langoose.Api/Controllers/DictionaryController.cs`
-- `apps/api/tests/Langoose.Api.UnitTests`
+- `apps/api/tests/Langoose.Core.UnitTests`
 - `apps/api/tests/Langoose.Api.IntegrationTests`
 - `apps/web/src/api.ts`
-- `apps/web/src/App.tsx`
 
-## Current Behavior
+## Data Model
 
-- Visible items are grouped by normalized English text and prefer the user-owned version when present.
-- Duplicate custom entries are merged during reads and writes.
-- Base vocabulary overlap does not create a second visible item.
-- Quick add determines phrase vs word automatically when item kind is missing.
-- Import requires header order starting with `English term`, `Russian translation(s)`, `Type`.
-- Only `Notes` and `Tags` are allowed as optional CSV columns.
-- Row-shape errors and malformed input prevent partial import.
-- Export returns only the user's visible custom items in CSV format.
-- Clearing custom data keeps session tokens.
+The dictionary uses a two-layer model:
 
-## Enrichment and Visibility
+- **SharedItem** — enriched English word/phrase concepts. Contains `NormalizedText`,
+  `PartOfSpeech`, `Difficulty`, `IsPublic`, `Source`. Only validated content lives here.
+- **UserItem** — per-user dictionary entries referencing a SharedItem. Contains
+  `RawEnglishText`, `RawGloss`, `Language`, `EnrichmentStatus`, notes, tags, status.
+  `SharedItemId` is nullable (null while pending enrichment).
+- **Gloss** — canonical translations linking SharedItem to a language.
+- **GlossSurfaceForm** — morphological variants pointing to a Gloss for dedup lookups.
 
-- Custom items require enrichment (AI-generated or user-provided context) before they appear in study cards.
-- See `docs/agent/enrichment-guidance.md` for enrichment states and the shared content layer model.
+## Visibility Rules
+
+- Users see all public SharedItems (base dictionary) plus their own UserItems that
+  have been enriched (SharedItemId is not null).
+- Pending UserItems (SharedItemId is null) are visible in the dictionary list but
+  excluded from study cards.
+- User-contributed SharedItems have `IsPublic = false` — they don't appear for other
+  users. Admin validation can promote them to public.
+
+## Quick Add Flow
+
+1. Normalize the English text.
+2. Look up GlossSurfaceForm for the user's gloss in the target language.
+3. If a match is found → Gloss → SharedItem → create UserItem linked to it (Enriched).
+4. If no match → create UserItem with `SharedItemId = null`, `EnrichmentStatus = Pending`.
+   The background worker enriches it later.
+5. Phrase vs word determined automatically from input (contains spaces → phrase).
+
+## Duplicate Handling
+
+- Dedup key is GlossSurfaceForm → Gloss → SharedItem. Two users adding the same word
+  with different morphological forms of the same gloss land on the same SharedItem.
+- If a user already has a UserItem for a given SharedItem, the existing UserItem is
+  updated (merged) rather than creating a duplicate.
+- Base vocabulary overlap: if the user adds a word that matches an existing public
+  SharedItem, they get a UserItem linked to it without triggering enrichment.
+
+## CSV Import
+
+- Required header order: English term, Russian translation(s), Type.
+- Optional columns: Notes, Tags.
+- Row-shape errors and malformed input prevent partial import — no half-imported files.
+- Each row follows the quick add flow (GlossSurfaceForm lookup → link or create Pending).
+- Response includes count of items pending enrichment.
+
+## CSV Export
+
+- Returns the user's UserItems joined with SharedItem and Gloss data.
+- Only enriched items with SharedItemId are exported.
+
+## Clear Custom Data
+
+- Deletes all UserItems, UserCustomSentences, and UserProgress for non-public items.
+- Preserves SharedItems (shared content layer).
+- Preserves UserProgress for public items (base dictionary study progress).
+- Does not revoke active sessions.
 
 ## Review Checklist
 
-- Did duplicate normalization still collapse visible entries correctly?
-- Did CSV validation remain strict and predictable?
-- Did import skip base-overlap and duplicate rows correctly?
-- Did export still match the intended visible custom subset?
-- Did clear-custom-data avoid revoking sessions?
+- Does GlossSurfaceForm lookup correctly dedup across morphological variants?
+- Does CSV validation remain strict and predictable?
+- Does import skip base-overlap and duplicate rows correctly?
+- Does export include SharedItem + Gloss data for enriched items?
+- Does clear-custom-data preserve SharedItems and base dictionary progress?
+- Does clear-custom-data avoid revoking sessions?

--- a/docs/agent/efcore-structure.md
+++ b/docs/agent/efcore-structure.md
@@ -10,21 +10,21 @@
 ## Entities
 
 All entities use `Guid` primary keys generated with `Guid.CreateVersion7()` (time-ordered,
-better for B-tree indexing in PostgreSQL).
+better for B-tree indexing in PostgreSQL). Mapping tables use composite primary keys.
 
 ### App Database (AppDbContext)
 
 | Entity | Table | Key Relationships |
 |--------|-------|-------------------|
-| SharedItem | shared_items | Has many Glosses, ExampleSentences |
-| Gloss | glosses | FK → SharedItem. Has many GlossSurfaceForms |
-| GlossSurfaceForm | gloss_surface_forms | FK → Gloss |
-| ExampleSentence | example_sentences | FK → SharedItem |
-| UserItem | user_items | FK → SharedItem (nullable) |
-| UserCustomSentence | user_custom_sentences | FK → UserItem |
-| UserProgress | user_progress | FK → SharedItem. Unique (UserId, SharedItemId) |
-| StudyEvent | study_events | FK → SharedItem, FK → ExampleSentence (nullable) |
-| ContentFlag | content_flags | FK → SharedItem |
+| DictionaryEntry | dictionary_entries | Self-ref BaseEntryId, has many EntryContexts |
+| EntryTranslation | entry_translations | Composite PK (SourceEntryId, TargetEntryId) |
+| EntryContext | entry_contexts | FK → DictionaryEntry |
+| ContextTranslation | context_translations | Composite PK (SourceContextId, TargetContextId) |
+| UserDictionaryEntry | user_dictionary_entries | FK → DictionaryEntry (nullable) |
+| UserEntryContext | user_entry_contexts | FK → UserDictionaryEntry |
+| UserProgress | user_progress | FK → DictionaryEntry. Unique (UserId, DictionaryEntryId) |
+| StudyEvent | study_events | FK → DictionaryEntry, FK → EntryContext (nullable) |
+| ContentFlag | content_flags | FK → DictionaryEntry |
 | ImportRecord | import_records | No FKs to content tables |
 
 ### Auth Database (AuthDbContext)
@@ -37,17 +37,18 @@ Unchanged. Contains `AuthUser`, `AuthSession`, and OpenIddict tables.
 - Use `ApplyConfigurationsFromAssembly` in `AppDbContext.OnModelCreating`.
 - Enum fields stored as strings via `HasConversion<string>()`.
 - PostgreSQL arrays (`text[]`) for `List<string>` properties (Tags, etc.).
+- Composite PKs via `HasKey(x => new { x.A, x.B })` for mapping tables.
 - Services use `AppDbContext` directly — no repository-per-entity abstraction.
-- Keep EF-specific concerns out of controllers. Controllers call services.
+- Keep EF-specific concerns out of controllers.
 
 ## Key Indexes
 
-- `SharedItem`: index on `NormalizedText`.
-- `Gloss`: unique on `(SharedItemId, Language, CanonicalForm)`.
-- `GlossSurfaceForm`: unique on `(GlossId, SurfaceForm)`, index on `SurfaceForm` for fast lookup.
-- `UserItem`: index on `UserId`, index on `(EnrichmentStatus)` for worker polling.
-- `UserProgress`: unique on `(UserId, SharedItemId)`.
-- `ExampleSentence`: index on `SharedItemId`.
+- `DictionaryEntry`: index on `(Language, Text)`, index on `BaseEntryId`.
+- `EntryTranslation`: PK `(SourceEntryId, TargetEntryId)`.
+- `EntryContext`: index on `DictionaryEntryId`.
+- `ContextTranslation`: PK `(SourceContextId, TargetContextId)`.
+- `UserDictionaryEntry`: index on `UserId`, index on `EnrichmentStatus`.
+- `UserProgress`: unique on `(UserId, DictionaryEntryId)`.
 
 ## Migrations
 
@@ -60,18 +61,15 @@ Unchanged. Contains `AuthUser`, `AuthSession`, and OpenIddict tables.
 ## Seeding
 
 - `DatabaseSeeder` and `SeedDataLoader` in `Data/Seeding/`.
-- `base-store.json` contains SharedItems with Glosses and ExampleSentences.
-- ExampleSentences in seed data include `ExpectedAnswer`, `GrammarHint`,
-  `SentenceTranslation`, and `Difficulty`.
-- GlossSurfaceForm entries seeded with canonical forms for base items.
+- `base-store.json` contains DictionaryEntries (base forms + derived forms),
+  EntryTranslations, EntryContexts, and ContextTranslations.
 - Seeding is empty-database-only via `Langoose.DbTool seed-app`.
 
 ## Review Checklist
 
 - Are all Guid PKs using `Guid.CreateVersion7()`?
+- Are mapping tables using composite PKs?
 - Are entity configurations in separate files per entity?
 - Are enum fields stored as strings?
-- Are indexes appropriate for query patterns (especially GlossSurfaceForm lookup)?
+- Are indexes appropriate for query patterns?
 - Are migrations discoverable and runnable?
-- Is `Program.cs` still simple?
-- Did tests keep exercising business rules rather than EF internals?

--- a/docs/agent/efcore-structure.md
+++ b/docs/agent/efcore-structure.md
@@ -1,26 +1,77 @@
 # Langoose EF Core Structure Guidance
 
-## Preferred Layout
+## Layout
 
-- `apps/api/src/Langoose.Domain` for shared persisted models and domain-facing abstractions.
-- `apps/api/src/Langoose.Data` for `AppDbContext`, configurations, migrations, and seeding.
-- `apps/api/src/Langoose.Auth.Data` for auth `DbContext`, auth configuration, and auth migrations.
-- `apps/api/tests/Langoose.Api.UnitTests`
-- `apps/api/tests/Langoose.Api.IntegrationTests`
+- `apps/api/src/Langoose.Domain` — entity classes, enums, constants.
+- `apps/api/src/Langoose.Data` — `AppDbContext`, entity configurations, migrations, seeding.
+- `apps/api/src/Langoose.Auth.Data` — auth `DbContext`, auth configuration, auth migrations.
+- `apps/api/src/Langoose.Core` — services that use `AppDbContext` directly.
 
-## What Belongs Where
+## Entities
 
-- Keep EF-specific concerns out of controllers.
-- Keep service-layer business rules in `apps/api/src/Langoose.Api/Services`.
-- Keep shared persisted models in `apps/api/src/Langoose.Domain` when both API behavior and EF Core depend on them.
-- Prefer one `IEntityTypeConfiguration<T>` file per entity once mappings stop being tiny.
-- Prefer `ApplyConfigurationsFromAssembly` over a large inline mapping file.
-- Treat repositories, extra abstractions, and separate migrations projects as opt-in complexity, not default architecture.
+All entities use `Guid` primary keys generated with `Guid.CreateVersion7()` (time-ordered,
+better for B-tree indexing in PostgreSQL).
+
+### App Database (AppDbContext)
+
+| Entity | Table | Key Relationships |
+|--------|-------|-------------------|
+| SharedItem | shared_items | Has many Glosses, ExampleSentences |
+| Gloss | glosses | FK → SharedItem. Has many GlossSurfaceForms |
+| GlossSurfaceForm | gloss_surface_forms | FK → Gloss |
+| ExampleSentence | example_sentences | FK → SharedItem |
+| UserItem | user_items | FK → SharedItem (nullable) |
+| UserCustomSentence | user_custom_sentences | FK → UserItem |
+| UserProgress | user_progress | FK → SharedItem. Unique (UserId, SharedItemId) |
+| StudyEvent | study_events | FK → SharedItem, FK → ExampleSentence (nullable) |
+| ContentFlag | content_flags | FK → SharedItem |
+| ImportRecord | import_records | No FKs to content tables |
+
+### Auth Database (AuthDbContext)
+
+Unchanged. Contains `AuthUser`, `AuthSession`, and OpenIddict tables.
+
+## Conventions
+
+- One `IEntityTypeConfiguration<T>` per entity in `Data/Configurations/`.
+- Use `ApplyConfigurationsFromAssembly` in `AppDbContext.OnModelCreating`.
+- Enum fields stored as strings via `HasConversion<string>()`.
+- PostgreSQL arrays (`text[]`) for `List<string>` properties (Tags, etc.).
+- Services use `AppDbContext` directly — no repository-per-entity abstraction.
+- Keep EF-specific concerns out of controllers. Controllers call services.
+
+## Key Indexes
+
+- `SharedItem`: index on `NormalizedText`.
+- `Gloss`: unique on `(SharedItemId, Language, CanonicalForm)`.
+- `GlossSurfaceForm`: unique on `(GlossId, SurfaceForm)`, index on `SurfaceForm` for fast lookup.
+- `UserItem`: index on `UserId`, index on `(EnrichmentStatus)` for worker polling.
+- `UserProgress`: unique on `(UserId, SharedItemId)`.
+- `ExampleSentence`: index on `SharedItemId`.
+
+## Migrations
+
+- No production data yet — fresh migrations are acceptable for major model reworks.
+- Delete old migration files and create a new `InitialFoundation` migration.
+- App migrations: `dotnet ef migrations add <Name> --project apps/api/src/Langoose.Data --startup-project apps/api/src/Langoose.Api`
+- Auth migrations: `dotnet ef migrations add <Name> --project apps/api/src/Langoose.Auth.Data --startup-project apps/api/src/Langoose.Api`
+- Local/Docker: auto-applied on startup. Hosted: applied via `Langoose.DbTool`.
+
+## Seeding
+
+- `DatabaseSeeder` and `SeedDataLoader` in `Data/Seeding/`.
+- `base-store.json` contains SharedItems with Glosses and ExampleSentences.
+- ExampleSentences in seed data include `ExpectedAnswer`, `GrammarHint`,
+  `SentenceTranslation`, and `Difficulty`.
+- GlossSurfaceForm entries seeded with canonical forms for base items.
+- Seeding is empty-database-only via `Langoose.DbTool seed-app`.
 
 ## Review Checklist
 
-- Did the change reduce persistence coupling in `apps/api`?
-- Are project references and namespaces straightforward?
-- Are migrations still discoverable and runnable?
+- Are all Guid PKs using `Guid.CreateVersion7()`?
+- Are entity configurations in separate files per entity?
+- Are enum fields stored as strings?
+- Are indexes appropriate for query patterns (especially GlossSurfaceForm lookup)?
+- Are migrations discoverable and runnable?
 - Is `Program.cs` still simple?
 - Did tests keep exercising business rules rather than EF internals?

--- a/docs/agent/enrichment-guidance.md
+++ b/docs/agent/enrichment-guidance.md
@@ -2,49 +2,145 @@
 
 ## Purpose
 
-Enrichment is the process of generating example sentences, translation hints, accepted variants,
-and difficulty metadata for dictionary items. It is a shared content layer: AI-generated enrichment
-is reusable across all users, while user-provided custom context is private per user.
+Enrichment generates example sentences, translations, difficulty metadata, grammar hints,
+and gloss normalization data for dictionary entries. It is a shared content layer:
+AI-generated content lives in `SharedItem` and is reusable across all users. User-provided
+custom context lives in `UserItem` / `UserCustomSentence` and is private per user.
 
-## Architecture Decisions
+## Domain Model
 
-- Enrichment runs as an async background process after a word is added.
-- Shared enrichment: if an item with the same normalized English text is already enriched, reuse that result.
-- User custom context (own sentences, translations) takes priority over AI-generated content and remains private.
-- Provider: best available free-tier LLM (currently Gemini Flash). Abstracted behind an interface to allow swapping.
-- Batch processing for CSV imports and bulk operations, respecting external API rate limits.
+### SharedItem
 
-## Enrichment States
+The English-word-concept table. Only contains validated/enriched content — never pending
+or failed entries. Keyed by `NormalizedText`. Has `IsPublic` flag (true for curated base
+items, false for user-contributed until admin validation). Has `Source` (Base or
+UserContributed).
 
-Each dictionary item has one of three enrichment states that determine study card eligibility:
+### Gloss
 
-1. **Custom context provided** — the user supplied their own sentences/translations. Ready for study.
-2. **AI-enriched** — background enrichment completed successfully. Ready for study.
-3. **Pending enrichment** — no custom context and not yet AI-enriched. Hidden from study cards.
+Links a SharedItem to a canonical translation in a target language. One SharedItem can
+have multiple glosses per language (e.g., "book" → "книга" as noun, "забронировать" as
+verb are separate SharedItems, each with their own Gloss). Language-agnostic — the
+`Language` field supports future expansion beyond Russian.
 
-The frontend should indicate the current enrichment state to the user.
+### GlossSurfaceForm
+
+Maps morphological variants to a canonical Gloss. When a user types "книгу", the lookup
+path is: GlossSurfaceForm("книгу") → Gloss("книга") → SharedItem. Populated by the LLM
+during enrichment. Grows over time as new forms are encountered.
+
+### ExampleSentence
+
+The actual study material. Each sentence is a complete learning context:
+- `SentenceText` / `ClozeText` — the English sentence with and without the gap
+- `ExpectedAnswer` — the exact form required by this sentence (e.g., "books", "booked")
+- `GrammarHint` — what form the gap expects ("infinitive", "past simple", "plural", etc.)
+- `SentenceTranslation` — full sentence translation in the target language
+- `Difficulty` — per-sentence, not per-word (same word can be A1 in a simple sentence,
+  B2 in an academic context)
+- `Language` — target language for translation
+- `Origin` — Dataset or Ai
+
+### UserItem
+
+Per-user custom dictionary entry. Owns the enrichment lifecycle:
+- `SharedItemId` is nullable — null while pending enrichment
+- `EnrichmentStatus`: Pending, Enriched, Failed
+- `EnrichmentAttempts` and `EnrichmentNotBefore` for retry backoff
+- Preserves `RawEnglishText` and `RawGloss` (what the user typed)
+
+When enrichment succeeds, a SharedItem is created (or an existing one is found),
+and UserItem.SharedItemId is set. When enrichment fails after max retries, the
+UserItem is marked Failed.
+
+### UserCustomSentence
+
+Private per-user examples with the same fields as ExampleSentence. Linked to UserItem,
+not SharedItem.
+
+## Architecture
+
+### Provider Interface
+
+`IEnrichmentProvider` in Domain defines:
+```
+Task<EnrichmentResult[]> EnrichBatchAsync(EnrichmentRequest[] batch, CancellationToken)
+```
+
+Batch-oriented by design — multiple terms per LLM call.
+
+### Implementations (in Core/Providers)
+
+- `LocalEnrichmentProvider` — static lexicon, sync fallback, used when AI is off
+- `GeminiEnrichmentProvider` — Gemini Flash REST API, structured JSON response
+
+### Background Worker
+
+`EnrichmentBackgroundService` in the Worker project:
+1. Polls `UserItems` with `EnrichmentStatus = Pending` in configurable batches
+2. Checks GlossSurfaceForm for existing matches (skip already-enriched concepts)
+3. Calls `IEnrichmentProvider.EnrichBatchAsync()`
+4. Creates SharedItem + Gloss + GlossSurfaceForm + ExampleSentences
+5. Links UserItem.SharedItemId, sets EnrichmentStatus → Enriched
+6. On failure: increments EnrichmentAttempts; marks Failed after MaxRetries
+
+Feature flag `Features.EnableAiEnrichment` controls whether the worker processes jobs.
 
 ## Content Generation
 
-For each item, enrichment should produce:
+For each term, the LLM produces:
+- Canonical gloss (lemma form) for the target language
+- Surface form variants (morphological forms of the gloss)
+- 1–3 example sentences, each with:
+  - English sentence containing the target term
+  - Cloze version with `____` replacing the term
+  - `ExpectedAnswer` — the exact form used in this sentence
+  - `GrammarHint` — what grammatical form the gap expects
+  - `SentenceTranslation` — full sentence translation
+  - `Difficulty` — per-sentence difficulty level (A1–B2)
+- Part of speech
+- General difficulty for the SharedItem (derived from sentence difficulties)
 
-- Natural example sentences with cloze gaps (multiple per item when possible)
-- Russian translation hints for each sentence
-- Accepted answer variants and common collocations
-- Difficulty inference (A1 through B2)
-- Part of speech when determinable
+## Enrichment Flow
 
-## Rate Limiting and Cost Control
+### User adds "book" + "книгу"
 
-- All external API calls go through a centralized enrichment queue.
-- Processing stays within the provider's free-tier limits.
-- Per-user rate limiting prevents abuse (excessive additions in short periods).
-- Enrichment failures are retried with backoff; items remain in pending state until success.
+1. Normalize text → "book"
+2. Look up GlossSurfaceForm for "книгу" in language "ru"
+3. If found → Gloss → SharedItem → create UserItem(SharedItemId=found, Enriched). Done.
+4. If not found → create UserItem(SharedItemId=null, Pending). Worker picks it up.
+
+### Worker processes pending UserItem
+
+1. Call LLM with RawEnglishText + RawGloss
+2. LLM returns canonical gloss "книга", surface forms ["книги", "книгу", "книге", "книгой"],
+   example sentences, part of speech, difficulty
+3. Find or create SharedItem by (NormalizedText, PartOfSpeech)
+4. Create Gloss("книга") + GlossSurfaceForm entries for all surface forms
+5. Create ExampleSentences with ExpectedAnswer, GrammarHint, SentenceTranslation, Difficulty
+6. Set UserItem.SharedItemId, EnrichmentStatus → Enriched
+
+### Second user adds "book" + "книге"
+
+1. GlossSurfaceForm("книге") → Gloss("книга") → SharedItem already exists
+2. Create UserItem linked to existing SharedItem. Enriched immediately. No LLM call.
+
+## Rate Limiting
+
+- Per-user throttle: max items per hour/day (configurable). Prevents abuse.
+- API-level: Gemini free-tier limits (requests per minute/day). In-memory sliding window
+  in the background worker.
+- On 429/5xx from Gemini: exponential backoff via `UserItem.EnrichmentNotBefore`.
+  Not counted as a failure.
+- Permanent failures (bad input, repeated LLM errors) marked Failed after MaxRetries.
 
 ## Review Checklist
 
-- Does new enrichment content follow the shared-then-private layering?
-- Does the enrichment state correctly gate study card visibility?
-- Are external API calls going through the queue with rate limiting?
-- Does CSV import trigger batch enrichment without exceeding API limits?
-- Is the enrichment provider abstracted behind an interface?
+- Does SharedItem only contain validated/enriched content?
+- Does UserItem own the pending/failed lifecycle?
+- Are GlossSurfaceForm entries created during enrichment for dedup?
+- Does the enrichment provider use batch-oriented async methods?
+- Are external API calls rate-limited (per-user and API-level)?
+- Does CSV import create Pending UserItems for batch processing?
+- Is the provider abstracted behind IEnrichmentProvider?
+- Do ExampleSentences have ExpectedAnswer, GrammarHint, SentenceTranslation, and Difficulty?

--- a/docs/agent/enrichment-guidance.md
+++ b/docs/agent/enrichment-guidance.md
@@ -2,145 +2,115 @@
 
 ## Purpose
 
-Enrichment generates example sentences, translations, difficulty metadata, grammar hints,
-and gloss normalization data for dictionary entries. It is a shared content layer:
-AI-generated content lives in `SharedItem` and is reusable across all users. User-provided
-custom context lives in `UserItem` / `UserCustomSentence` and is private per user.
+Enrichment generates learning contexts, translations, grammar labels, difficulty
+metadata, and morphological form data for dictionary entries. It is a shared content
+layer: AI-generated content lives in `DictionaryEntry` / `EntryContext` and is
+reusable across all users. User-provided custom content lives in
+`UserDictionaryEntry` / `UserEntryContext` and is private per user.
 
 ## Domain Model
 
-### SharedItem
+### DictionaryEntry
 
-The English-word-concept table. Only contains validated/enriched content — never pending
-or failed entries. Keyed by `NormalizedText`. Has `IsPublic` flag (true for curated base
-items, false for user-contributed until admin validation). Has `Source` (Base or
-UserContributed).
+A word or form in any language. Base forms and derived forms live in the same table,
+linked by `BaseEntryId`. Only contains validated/enriched content.
 
-### Gloss
+- `("en", "book", base, "verb")` — base form
+- `("en", "booked", →book, "past simple")` — derived form
+- `("ru", "книга", base, "noun")` — base form
+- `("ru", "книгу", →книга, "accusative")` — derived form
 
-Links a SharedItem to a canonical translation in a target language. One SharedItem can
-have multiple glosses per language (e.g., "book" → "книга" as noun, "забронировать" as
-verb are separate SharedItems, each with their own Gloss). Language-agnostic — the
-`Language` field supports future expansion beyond Russian.
+### EntryTranslation
 
-### GlossSurfaceForm
+Links base forms across languages as word-level translation hints. Stored
+bidirectionally. Composite PK `(SourceEntryId, TargetEntryId)`.
 
-Maps morphological variants to a canonical Gloss. When a user types "книгу", the lookup
-path is: GlossSurfaceForm("книгу") → Gloss("книга") → SharedItem. Populated by the LLM
-during enrichment. Grows over time as new forms are encountered.
+### EntryContext
 
-### ExampleSentence
+A learning context linked to a specific DictionaryEntry form. Contains `Text`
+(full sentence) and `Cloze` (sentence with gap). The expected answer and grammar
+hint are derived from the linked entry — not stored on the context.
 
-The actual study material. Each sentence is a complete learning context:
-- `SentenceText` / `ClozeText` — the English sentence with and without the gap
-- `ExpectedAnswer` — the exact form required by this sentence (e.g., "books", "booked")
-- `GrammarHint` — what form the gap expects ("infinitive", "past simple", "plural", etc.)
-- `SentenceTranslation` — full sentence translation in the target language
-- `Difficulty` — per-sentence, not per-word (same word can be A1 in a simple sentence,
-  B2 in an academic context)
-- `Language` — target language for translation
-- `Origin` — Dataset or Ai
+### ContextTranslation
 
-### UserItem
+Links paired EntryContexts across languages. Stored bidirectionally. Composite PK.
 
-Per-user custom dictionary entry. Owns the enrichment lifecycle:
-- `SharedItemId` is nullable — null while pending enrichment
+### UserDictionaryEntry
+
+Per-user custom entry. Owns the enrichment lifecycle:
+- `DictionaryEntryId` is nullable — null while pending enrichment
 - `EnrichmentStatus`: Pending, Enriched, Failed
 - `EnrichmentAttempts` and `EnrichmentNotBefore` for retry backoff
-- Preserves `RawEnglishText` and `RawGloss` (what the user typed)
 
-When enrichment succeeds, a SharedItem is created (or an existing one is found),
-and UserItem.SharedItemId is set. When enrichment fails after max retries, the
-UserItem is marked Failed.
+## Provider Interface
 
-### UserCustomSentence
-
-Private per-user examples with the same fields as ExampleSentence. Linked to UserItem,
-not SharedItem.
-
-## Architecture
-
-### Provider Interface
-
-`IEnrichmentProvider` in Domain defines:
+`IEnrichmentProvider` in Domain:
 ```
 Task<EnrichmentResult[]> EnrichBatchAsync(EnrichmentRequest[] batch, CancellationToken)
 ```
 
-Batch-oriented by design — multiple terms per LLM call.
+Batch-oriented — multiple terms per LLM call.
 
 ### Implementations (in Core/Providers)
 
-- `LocalEnrichmentProvider` — static lexicon, sync fallback, used when AI is off
+- `LocalEnrichmentProvider` — static lexicon, sync fallback
 - `GeminiEnrichmentProvider` — Gemini Flash REST API, structured JSON response
 
-### Background Worker
+## Background Worker
 
 `EnrichmentBackgroundService` in the Worker project:
-1. Polls `UserItems` with `EnrichmentStatus = Pending` in configurable batches
-2. Checks GlossSurfaceForm for existing matches (skip already-enriched concepts)
+1. Polls UserDictionaryEntries with `EnrichmentStatus = Pending` in batches
+2. Dedup check: look up raw translation as a DictionaryEntry form → base → EntryTranslation
 3. Calls `IEnrichmentProvider.EnrichBatchAsync()`
-4. Creates SharedItem + Gloss + GlossSurfaceForm + ExampleSentences
-5. Links UserItem.SharedItemId, sets EnrichmentStatus → Enriched
-6. On failure: increments EnrichmentAttempts; marks Failed after MaxRetries
+4. Creates DictionaryEntry (base + forms), EntryTranslation, EntryContext, ContextTranslation
+5. Links UserDictionaryEntry → DictionaryEntry, status → Enriched
+6. On failure: increment attempts; mark Failed after MaxRetries
 
-Feature flag `Features.EnableAiEnrichment` controls whether the worker processes jobs.
+Feature flag `Features.EnableAiEnrichment` controls processing.
 
 ## Content Generation
 
 For each term, the LLM produces:
-- Canonical gloss (lemma form) for the target language
-- Surface form variants (morphological forms of the gloss)
-- 1–3 example sentences, each with:
-  - English sentence containing the target term
-  - Cloze version with `____` replacing the term
-  - `ExpectedAnswer` — the exact form used in this sentence
-  - `GrammarHint` — what grammatical form the gap expects
-  - `SentenceTranslation` — full sentence translation
-  - `Difficulty` — per-sentence difficulty level (A1–B2)
-- Part of speech
-- General difficulty for the SharedItem (derived from sentence difficulties)
+- Base forms and derived forms (both languages) with grammar labels
+- EntryTranslation links between base forms (bidirectional)
+- 1–3 learning contexts, each with:
+  - Source language sentence + cloze (linked to specific source form)
+  - Target language sentence (linked to specific target form)
+  - ContextTranslation link between paired contexts
+  - Per-context difficulty (A1–B2)
 
 ## Enrichment Flow
 
 ### User adds "book" + "книгу"
 
-1. Normalize text → "book"
-2. Look up GlossSurfaceForm for "книгу" in language "ru"
-3. If found → Gloss → SharedItem → create UserItem(SharedItemId=found, Enriched). Done.
-4. If not found → create UserItem(SharedItemId=null, Pending). Worker picks it up.
+1. Look up DictionaryEntry("книгу", ru) → follow BaseEntryId → "книга"
+2. Check EntryTranslation for any linked English entry
+3. If found → create UserDictionaryEntry linked to it. Done.
+4. If not found → create UserDictionaryEntry(Pending). Worker picks it up.
 
-### Worker processes pending UserItem
+### Worker processes pending item
 
-1. Call LLM with RawEnglishText + RawGloss
-2. LLM returns canonical gloss "книга", surface forms ["книги", "книгу", "книге", "книгой"],
-   example sentences, part of speech, difficulty
-3. Find or create SharedItem by (NormalizedText, PartOfSpeech)
-4. Create Gloss("книга") + GlossSurfaceForm entries for all surface forms
-5. Create ExampleSentences with ExpectedAnswer, GrammarHint, SentenceTranslation, Difficulty
-6. Set UserItem.SharedItemId, EnrichmentStatus → Enriched
+1. LLM returns forms, translations, contexts
+2. Create DictionaryEntries, EntryTranslations, EntryContexts, ContextTranslations
+3. Link UserDictionaryEntry → DictionaryEntry, status → Enriched
 
 ### Second user adds "book" + "книге"
 
-1. GlossSurfaceForm("книге") → Gloss("книга") → SharedItem already exists
-2. Create UserItem linked to existing SharedItem. Enriched immediately. No LLM call.
+1. DictionaryEntry("книге", ru) found → base "книга" → EntryTranslation → "book"
+2. Linked immediately. No LLM call.
 
 ## Rate Limiting
 
-- Per-user throttle: max items per hour/day (configurable). Prevents abuse.
-- API-level: Gemini free-tier limits (requests per minute/day). In-memory sliding window
-  in the background worker.
-- On 429/5xx from Gemini: exponential backoff via `UserItem.EnrichmentNotBefore`.
-  Not counted as a failure.
-- Permanent failures (bad input, repeated LLM errors) marked Failed after MaxRetries.
+- Per-user throttle: max items per hour/day
+- API-level: Gemini free-tier limits, in-memory sliding window
+- Backoff: 429/5xx sets `EnrichmentNotBefore` with exponential delay
+- Permanent failure after MaxRetries
 
 ## Review Checklist
 
-- Does SharedItem only contain validated/enriched content?
-- Does UserItem own the pending/failed lifecycle?
-- Are GlossSurfaceForm entries created during enrichment for dedup?
-- Does the enrichment provider use batch-oriented async methods?
-- Are external API calls rate-limited (per-user and API-level)?
-- Does CSV import create Pending UserItems for batch processing?
-- Is the provider abstracted behind IEnrichmentProvider?
-- Do ExampleSentences have ExpectedAnswer, GrammarHint, SentenceTranslation, and Difficulty?
+- Does DictionaryEntry only contain validated/enriched content?
+- Does UserDictionaryEntry own the pending/failed lifecycle?
+- Are derived forms created for dedup lookups?
+- Are EntryTranslation and ContextTranslation stored bidirectionally?
+- Does the provider use batch-oriented async methods?
+- Are external API calls rate-limited?

--- a/docs/agent/frontend-guidance.md
+++ b/docs/agent/frontend-guidance.md
@@ -6,12 +6,26 @@
 - Avoid state in `apps/web/src/App.tsx` that merely mirrors other known values.
 - Prefer named request and response shapes in `apps/web/src/api.ts`.
 - Update `apps/web/src/api.ts` first when backend contracts evolve.
+- Prefer the current lightweight frontend style: plain React state plus plain CSS
+  unless the change clearly needs more.
+
+## API Integration
+
+- Controllers return flat DTOs (not raw domain models). The frontend never needs to
+  understand the SharedItem/UserItem/Gloss split — the API flattens it.
+- Dictionary item responses include `enrichmentStatus` for pending/enriched/failed display.
+- Study card responses include composite hint fields: `sentenceTranslation`, `glosses`
+  (array), `grammarHint`, `difficulty` (per-sentence).
+- When pending items exist, poll the dictionary endpoint on an interval to refresh status.
+  Stop polling when no items are pending.
 
 ## TypeScript
 
 - Keep `strict: true` in `apps/web/tsconfig.json`.
-- Consider `exactOptionalPropertyTypes` and `noUncheckedIndexedAccess` only when the repo is ready to absorb the fixes.
-- Evaluate `moduleResolution: "bundler"` against current Vite defaults when the frontend TS config is next revisited, but do not change it by rote.
+- Consider `exactOptionalPropertyTypes` and `noUncheckedIndexedAccess` only when the
+  repo is ready to absorb the fixes.
+- Evaluate `moduleResolution: "bundler"` against current Vite defaults when the frontend
+  TS config is next revisited, but do not change it by rote.
 - Prefer `unknown` plus narrowing over `any`.
 
 ## Review Checklist
@@ -20,6 +34,7 @@
 - Is this state minimal?
 - Is the API payload or response type precise enough to catch drift?
 - Should this section be extracted into a focused child component?
+- Does the frontend type match the backend DTO shape (not the domain model)?
 
 ## Sources
 

--- a/docs/agent/frontend-guidance.md
+++ b/docs/agent/frontend-guidance.md
@@ -12,10 +12,12 @@
 ## API Integration
 
 - Controllers return flat DTOs (not raw domain models). The frontend never needs to
-  understand the SharedItem/UserItem/Gloss split — the API flattens it.
+  understand the DictionaryEntry/UserDictionaryEntry/EntryTranslation split — the API
+  flattens it.
 - Dictionary item responses include `enrichmentStatus` for pending/enriched/failed display.
-- Study card responses include composite hint fields: `sentenceTranslation`, `glosses`
-  (array), `grammarHint`, `difficulty` (per-sentence).
+- Study card responses include: `cloze`, sentence translation (from paired context),
+  `translations` (word-level from EntryTranslation), `grammarHint` (from
+  DictionaryEntry.GrammarLabel), `difficulty` (from EntryContext).
 - When pending items exist, poll the dictionary endpoint on an interval to refresh status.
   Stop polling when no items are pending.
 

--- a/docs/agent/study-engine.md
+++ b/docs/agent/study-engine.md
@@ -2,39 +2,92 @@
 
 ## Main Files
 
-- `apps/api/src/Langoose.Api/Services/StudyService.cs`
-- `apps/api/src/Langoose.Api/Services/TextNormalizer.cs`
-- `apps/api/tests/Langoose.Api.UnitTests`
+- `apps/api/src/Langoose.Core/Services/StudyService.cs`
+- `apps/api/src/Langoose.Core/Utilities/TextNormalizer.cs`
+- `apps/api/tests/Langoose.Core.UnitTests`
 - `apps/api/tests/Langoose.Api.IntegrationTests`
 
-## Current Behavior
+## Study Unit
 
-- Due cards come from visible dictionary items, not hidden duplicates.
-- Missing review states are created lazily for visible items.
-- Card selection orders by due time and success count, then biases toward custom items when custom is not overrepresented.
-- Exact matches return `Correct`.
-- Accepted variants return `AlmostCorrect` with `AcceptedVariant`.
-- Missing articles, inflection variants, and minor typos are intentionally tolerated as `AlmostCorrect`.
-- Phrase similarity can also yield `AlmostCorrect`.
+The study unit is an **ExampleSentence with a gap**, not a word. Each sentence is a
+complete learning context with its own difficulty, expected answer form, grammar hint,
+and full translation.
 
-## Enrichment Eligibility
+### Study Card Content
 
-- A card is only eligible for study if its dictionary item has enrichment (AI-generated or user-provided context).
-- Items in pending enrichment state are excluded from card selection.
-- See `docs/agent/enrichment-guidance.md` for enrichment states.
+```
+ClozeText:           "I need to ____ a hotel for our trip."
+SentenceTranslation: "Мне нужно забронировать отель для нашей поездки."
+Glosses:             ["забронировать"]  (canonical forms from Gloss table)
+GrammarHint:         "infinitive"
+Difficulty:          "B1"               (per-sentence, from ExampleSentence)
+```
+
+The hint is composite:
+- `SentenceTranslation` — full sentence in the target language
+- Canonical glosses for the SharedItem in the user's language (from Gloss table)
+- `GrammarHint` — what grammatical form the gap expects
+
+## Card Selection
+
+1. Build the studyable pool:
+   - All public SharedItems (base dictionary)
+   - SharedItems linked from the user's enriched UserItems (SharedItemId is not null)
+2. Pick a SharedItem using scheduling (UserProgress order by DueAtUtc, bias toward
+   custom items when not overrepresented).
+3. Pick an ExampleSentence for that SharedItem (rotate across multiple contexts).
+   Also include UserCustomSentences if the user has any.
+4. Build the study card from the selected sentence.
+
+### Enrichment Eligibility
+
+Items pending enrichment are excluded from the pool. Only SharedItems with enriched
+ExampleSentences participate in study. UserItems with `SharedItemId = null` (pending)
+or `EnrichmentStatus = Failed` are not studyable.
+
+## Answer Evaluation
+
+Compare user input against `ExampleSentence.ExpectedAnswer`:
+- The sentence determines the correct form — "book", "books", "booked" depending on context.
+- Use Levenshtein similarity via TextNormalizer for typo tolerance.
+- Missing articles, inflection variants, and minor typos are tolerated as `AlmostCorrect`.
+- Record `ExampleSentenceId` in StudyEvent to track which context was tested.
+
+### Verdict Categories
+
+- `Correct` — exact match or near-exact match with the ExpectedAnswer.
+- `AlmostCorrect` — minor typo (Levenshtein), missing article, inflection variant.
+- `Incorrect` — meaning mismatch or substantially wrong answer.
+
+## UserProgress
+
+Renamed from ReviewState. Tracks spaced repetition per (UserId, SharedItemId):
+- `Stability`, `DueAtUtc`, `LapseCount`, `SuccessCount`, `LastSeenAtUtc`
+- Created lazily when a SharedItem first appears in study for a user.
+- Unique constraint on (UserId, SharedItemId).
+
+## Dashboard
+
+- **Total items**: public SharedItems + user's enriched UserItems.
+- **Due now**: count from UserProgress where DueAtUtc <= now.
+- **New items**: items in pool with no UserProgress row.
+- **Studied today**: StudyEvents in last 24 hours.
 
 ## Scheduling Direction
 
 - The current scheduler uses fixed stability increments and fixed intervals.
 - M3 plans adoption of FSRS (Free Spaced Repetition Scheduler) to replace it.
-- Error analytics should feed back into scheduling: frequently missed words surface more often.
+- Error analytics should feed back into scheduling: frequently missed words surface
+  more often.
 - All scheduling algorithm decisions and parameters must be documented when changed.
 
 ## Review Checklist
 
-- Did normalization behavior change?
+- Did answer evaluation still compare against ExampleSentence.ExpectedAnswer?
+- Did Levenshtein tolerance thresholds change?
 - Did verdict categories or feedback codes change?
 - Did scheduler intervals change?
 - Did card balancing between base and custom items change?
-- Did dashboard counts still match the same visibility rules?
+- Did dashboard counts still match the visibility rules?
 - Did card eligibility still respect enrichment state?
+- Is ExampleSentenceId recorded in StudyEvent?

--- a/docs/agent/study-engine.md
+++ b/docs/agent/study-engine.md
@@ -9,85 +9,70 @@
 
 ## Study Unit
 
-The study unit is an **ExampleSentence with a gap**, not a word. Each sentence is a
-complete learning context with its own difficulty, expected answer form, grammar hint,
-and full translation.
+The study unit is an **EntryContext** — a sentence with a cloze gap linked to a
+specific DictionaryEntry form. The expected answer and grammar hint are derived
+from the linked entry, not stored on the context.
 
 ### Study Card Content
 
 ```
-ClozeText:           "I need to ____ a hotel for our trip."
-SentenceTranslation: "Мне нужно забронировать отель для нашей поездки."
-Glosses:             ["забронировать"]  (canonical forms from Gloss table)
-GrammarHint:         "infinitive"
-Difficulty:          "B1"               (per-sentence, from ExampleSentence)
+Cloze:              "She ____ the room yesterday."
+Sentence hint:      "Она забронировала комнату вчера."  (paired context via ContextTranslation)
+Translations:       ["забронировать"]                   (via EntryTranslation)
+Grammar hint:       "past simple"                       (from DictionaryEntry.GrammarLabel)
+Expected answer:    "booked"                            (from DictionaryEntry.Text)
+Difficulty:         "B1"                                (from EntryContext.Difficulty)
 ```
-
-The hint is composite:
-- `SentenceTranslation` — full sentence in the target language
-- Canonical glosses for the SharedItem in the user's language (from Gloss table)
-- `GrammarHint` — what grammatical form the gap expects
 
 ## Card Selection
 
 1. Build the studyable pool:
-   - All public SharedItems (base dictionary)
-   - SharedItems linked from the user's enriched UserItems (SharedItemId is not null)
-2. Pick a SharedItem using scheduling (UserProgress order by DueAtUtc, bias toward
-   custom items when not overrepresented).
-3. Pick an ExampleSentence for that SharedItem (rotate across multiple contexts).
-   Also include UserCustomSentences if the user has any.
-4. Build the study card from the selected sentence.
-
-### Enrichment Eligibility
-
-Items pending enrichment are excluded from the pool. Only SharedItems with enriched
-ExampleSentences participate in study. UserItems with `SharedItemId = null` (pending)
-or `EnrichmentStatus = Failed` are not studyable.
+   - All public DictionaryEntries (base forms)
+   - DictionaryEntries linked from the user's enriched UserDictionaryEntries
+2. Exclude entries with no EntryContexts, pending/failed UserDictionaryEntries.
+3. Join UserProgress for scheduling (lazy create for new encounters).
+4. Order by DueAtUtc, then SuccessCount. Bias toward custom items.
+5. Pick a base entry → pick an EntryContext for one of its forms (rotate contexts).
+6. Include UserEntryContexts if the user has added their own.
 
 ## Answer Evaluation
 
-Compare user input against `ExampleSentence.ExpectedAnswer`:
-- The sentence determines the correct form — "book", "books", "booked" depending on context.
-- Use Levenshtein similarity via TextNormalizer for typo tolerance.
-- Missing articles, inflection variants, and minor typos are tolerated as `AlmostCorrect`.
-- Record `ExampleSentenceId` in StudyEvent to track which context was tested.
+Compare user input against the linked DictionaryEntry.Text (the expected form):
+- Levenshtein similarity via TextNormalizer for typo tolerance
+- Missing articles, inflection variants tolerated as AlmostCorrect
+- Record EntryContextId in StudyEvent for per-context analytics
 
-### Verdict Categories
+### Verdicts
 
-- `Correct` — exact match or near-exact match with the ExpectedAnswer.
-- `AlmostCorrect` — minor typo (Levenshtein), missing article, inflection variant.
-- `Incorrect` — meaning mismatch or substantially wrong answer.
+- `Correct` — exact match or near-exact
+- `AlmostCorrect` — minor typo, missing article, inflection variant
+- `Incorrect` — meaning mismatch
 
 ## UserProgress
 
-Renamed from ReviewState. Tracks spaced repetition per (UserId, SharedItemId):
-- `Stability`, `DueAtUtc`, `LapseCount`, `SuccessCount`, `LastSeenAtUtc`
-- Created lazily when a SharedItem first appears in study for a user.
-- Unique constraint on (UserId, SharedItemId).
+Tracks spaced repetition per (UserId, DictionaryEntryId). Created lazily.
+Unique constraint on (UserId, DictionaryEntryId).
 
 ## Dashboard
 
-- **Total items**: public SharedItems + user's enriched UserItems.
-- **Due now**: count from UserProgress where DueAtUtc <= now.
-- **New items**: items in pool with no UserProgress row.
-- **Studied today**: StudyEvents in last 24 hours.
+- Total items: public base entries + user's enriched entries
+- Due now: UserProgress where DueAtUtc <= now
+- New items: entries in pool with no UserProgress row
+- Studied today: StudyEvents in last 24h
 
 ## Scheduling Direction
 
-- The current scheduler uses fixed stability increments and fixed intervals.
-- M3 plans adoption of FSRS (Free Spaced Repetition Scheduler) to replace it.
-- Error analytics should feed back into scheduling: frequently missed words surface
-  more often.
-- All scheduling algorithm decisions and parameters must be documented when changed.
+- Current scheduler uses fixed stability increments and intervals.
+- M3 plans FSRS adoption.
+- Error analytics should feed back into scheduling.
+- All scheduling parameter changes must be documented.
 
 ## Review Checklist
 
-- Did answer evaluation still compare against ExampleSentence.ExpectedAnswer?
+- Did answer evaluation still compare against DictionaryEntry.Text?
 - Did Levenshtein tolerance thresholds change?
 - Did verdict categories or feedback codes change?
 - Did scheduler intervals change?
 - Did card balancing between base and custom items change?
 - Did dashboard counts still match the visibility rules?
-- Did card eligibility still respect enrichment state?
-- Is ExampleSentenceId recorded in StudyEvent?
+- Is EntryContextId recorded in StudyEvent?

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,161 @@
+# API Reference
+
+The API serves the React SPA and handles authentication, dictionary management,
+and study sessions. All endpoints are under `http://localhost:5000` locally or
+`/api` through the Vercel proxy in staging.
+
+## Authentication
+
+All mutating endpoints require an antiforgery token. The SPA fetches it on
+bootstrap and includes it in subsequent requests.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/auth/antiforgery` | Get CSRF token |
+| POST | `/auth/sign-up` | Register a new account |
+| POST | `/auth/sign-in` | Sign in |
+| POST | `/auth/sign-out` | Sign out |
+| GET | `/auth/me` | Get current user (or 401) |
+
+Auth uses cookie-based sessions with ASP.NET Core Identity + OpenIddict.
+See `docs/auth-mvp-decision.md` for the design rationale.
+
+## Dictionary
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/dictionary/items` | List user's visible dictionary items |
+| POST | `/dictionary/items` | Add a word to the dictionary |
+| PATCH | `/dictionary/items/{id}` | Update a dictionary item |
+| POST | `/dictionary/import` | Import words from CSV |
+| GET | `/dictionary/export` | Export custom words as CSV |
+| DELETE | `/dictionary/custom-data` | Clear all custom data |
+
+### GET /dictionary/items
+
+Returns a flat array of dictionary items combining DictionaryEntry +
+UserDictionaryEntry data. Each item includes:
+
+- `id` — the entry ID
+- `text` — the word or phrase
+- `translations` — array of canonical translations in the user's language
+  (from EntryTranslation → target language base entries)
+- `partOfSpeech`, `difficulty`
+- `isCustom` — whether this is a user-added item
+- `enrichmentStatus` — "pending", "enriched", or "failed"
+- `notes`, `tags`
+
+### POST /dictionary/items
+
+Add a word. Request body:
+
+```json
+{
+  "text": "book",
+  "translation": "книгу",
+  "language": "ru",
+  "notes": "",
+  "tags": []
+}
+```
+
+The system looks up the translation as a DictionaryEntry form, follows
+`BaseEntryId`, checks EntryTranslation links. If a match is found, the user
+entry links to the existing DictionaryEntry immediately. Otherwise, a pending
+UserDictionaryEntry is created for background enrichment.
+
+### POST /dictionary/import
+
+Upload CSV content. Required columns: English term, translation(s), type.
+Optional: Notes, Tags. Returns import statistics including pending enrichment count.
+
+## Study
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/study/next` | Get the next study card |
+| POST | `/study/answer` | Submit an answer |
+| GET | `/study/dashboard` | Get progress dashboard |
+
+### GET /study/next
+
+Returns the next due study card or 404 if nothing is due:
+
+```json
+{
+  "entryId": "...",
+  "contextId": "...",
+  "cloze": "She ____ the room yesterday.",
+  "sentenceTranslation": "Она забронировала комнату вчера.",
+  "translations": ["забронировать"],
+  "grammarHint": "past simple",
+  "difficulty": "B1",
+  "sourceType": "base"
+}
+```
+
+Fields derived at query time:
+- `cloze` — from EntryContext.Cloze
+- `sentenceTranslation` — from the paired EntryContext via ContextTranslation
+- `translations` — from EntryTranslation (target language base entries)
+- `grammarHint` — from the linked DictionaryEntry.GrammarLabel
+- Expected answer — from the linked DictionaryEntry.Text (not sent to client)
+
+### POST /study/answer
+
+Submit an answer for evaluation:
+
+```json
+{
+  "entryId": "...",
+  "contextId": "...",
+  "submittedAnswer": "booked"
+}
+```
+
+Returns the verdict with feedback:
+
+```json
+{
+  "verdict": "correct",
+  "normalizedAnswer": "booked",
+  "expectedAnswer": "booked",
+  "feedbackCode": "exact_match",
+  "nextDueAtUtc": "2026-04-12T10:00:00Z"
+}
+```
+
+### GET /study/dashboard
+
+Returns study progress:
+
+```json
+{
+  "totalItems": 150,
+  "dueNow": 12,
+  "newItems": 5,
+  "baseItems": 120,
+  "customItems": 30,
+  "studiedToday": 8
+}
+```
+
+## Content
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/content/flag` | Report a content quality issue |
+
+## Health
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Health check endpoint |
+
+## Notes
+
+- Enum values are serialized as snake_case strings (e.g., `"exact_match"`,
+  `"almost_correct"`).
+- The frontend client types in `apps/web/src/api.ts` mirror these contracts.
+- CSV export uses `text/csv` content type.
+- 202 and 204 responses have no body.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,141 @@
+# Architecture
+
+Langoose is an English vocabulary learning app for Russian speakers. The backend is
+ASP.NET Core with PostgreSQL; the frontend is React + TypeScript + Vite.
+
+## System Overview
+
+```
+┌─────────┐       ┌─────────────┐       ┌────────────┐
+│  React  │──────▶│  ASP.NET    │──────▶│ PostgreSQL │
+│  SPA    │  API  │  Core API   │  EF   │  (app +    │
+│         │◀──────│             │  Core │   auth)    │
+└─────────┘       └─────────────┘       └────────────┘
+                  ┌─────────────┐              │
+                  │   Worker    │──────────────┘
+                  │  (enrichment│  EF Core
+                  │   pipeline) │
+                  └─────────────┘
+                        │
+                        ▼
+                  ┌─────────────┐
+                  │ Gemini Flash│
+                  │   (LLM)    │
+                  └─────────────┘
+```
+
+The API serves the SPA and handles authentication, dictionary management, and study
+sessions. The Worker is a separate process that runs background enrichment — polling
+pending items, calling the LLM, and writing enriched content back to the database.
+Both share the same PostgreSQL instance.
+
+## Onion Architecture
+
+Dependencies point inward. Domain has no dependencies; everything else depends on it.
+
+```
+┌──────────────────────────────────────────────┐
+│  Presentation                                │
+│  ┌──────────────┐  ┌──────────────────┐      │
+│  │     Api      │  │     Worker       │      │
+│  │ (controllers,│  │ (background      │      │
+│  │  DI, DTOs)   │  │  service, DI)    │      │
+│  └──────┬───────┘  └────────┬─────────┘      │
+├─────────┼───────────────────┼────────────────┤
+│  Core (service implementations, providers)   │
+│  ┌──────────────────────────────────────┐    │
+│  │ DictionaryService, StudyService,     │    │
+│  │ ContentService, EnrichmentService,   │    │
+│  │ LocalEnrichmentProvider,             │    │
+│  │ GeminiEnrichmentProvider,            │    │
+│  │ TextNormalizer                       │    │
+│  └──────────────────┬───────────────────┘    │
+├─────────────────────┼────────────────────────┤
+│  Data (EF Core persistence)                  │
+│  ┌──────────────────────────────────────┐    │
+│  │ AppDbContext, entity configurations, │    │
+│  │ migrations, seeding                  │    │
+│  └──────────────────┬───────────────────┘    │
+├─────────────────────┼────────────────────────┤
+│  Domain (innermost — no dependencies)        │
+│  ┌──────────────────────────────────────┐    │
+│  │ Entities, enums, constants,          │    │
+│  │ service interfaces                   │    │
+│  └──────────────────────────────────────┘    │
+└──────────────────────────────────────────────┘
+```
+
+### Layer Responsibilities
+
+| Layer | Project | What lives here |
+|-------|---------|-----------------|
+| Domain | `Langoose.Domain` | Entities, enums, constants, service interfaces. No dependencies. |
+| Data | `Langoose.Data` | AppDbContext, entity configurations, migrations, seeding. Depends on Domain. |
+| Core | `Langoose.Core` | Service implementations, enrichment providers, TextNormalizer. Depends on Domain + Data. |
+| Api | `Langoose.Api` | Controllers, request/response DTOs, middleware, DI composition. Depends on Core + Domain + Data + Auth.Data. |
+| Worker | `Langoose.Worker` | EnrichmentBackgroundService, DI composition. Depends on Core + Domain + Data. |
+
+Additional projects:
+- `Langoose.Auth.Data` — auth DbContext, Identity + OpenIddict persistence. Depends on Domain.
+- `Langoose.DbTool` — CLI for applying migrations and seeding in hosted environments. Depends on Data + Domain.
+
+### DTO Mapping
+
+Controllers own all mapping between request/response DTOs and domain models. Services
+never see DTOs — they accept and return domain entity types. This keeps the Core layer
+independent of API contract details.
+
+## Data Model
+
+The content model has 4 main tables plus 2 mapping tables:
+
+- **DictionaryEntry** — a word or form in any language (base forms and derived forms
+  in the same table, linked by `BaseEntryId`)
+- **EntryTranslation** — links base forms across languages (bidirectional)
+- **EntryContext** — a learning context (sentence + cloze gap) linked to a specific form
+- **ContextTranslation** — links paired contexts across languages (bidirectional)
+
+User-specific tables: **UserDictionaryEntry** (per-user entries with enrichment
+lifecycle), **UserEntryContext** (private learning contexts), **UserProgress**
+(spaced repetition state), **StudyEvent** (answer history).
+
+See [domain-model.md](domain-model.md) for the complete entity reference and ER diagram.
+
+## Project Map
+
+```
+apps/
+  api/
+    src/
+      Langoose.Domain/        Entities, enums, service interfaces
+      Langoose.Core/          Service implementations, providers
+      Langoose.Data/          EF Core, migrations, seeding
+      Langoose.Api/           Controllers, DTOs, middleware
+      Langoose.Worker/        Background enrichment host
+      Langoose.Auth.Data/     Auth persistence
+      Langoose.DbTool/        Migration/seeding CLI
+    tests/
+      Langoose.Core.UnitTests/
+      Langoose.Api.IntegrationTests/
+  web/
+    src/                      React + TypeScript SPA
+```
+
+## Databases
+
+Two PostgreSQL databases on the same server:
+- **langoose_app** — dictionary entries, learning contexts, study progress
+- **langoose_auth** — Identity users, sessions, OpenIddict tokens
+
+Separated so auth can be managed independently (different backup cadence,
+different migration lifecycle).
+
+## Deployment
+
+- **Local**: `docker compose up` for PostgreSQL, `dotnet run` for API and Worker,
+  `npm run dev` for frontend.
+- **Staging**: Vercel (web) + Railway (API) + Neon (PostgreSQL). Vercel proxies
+  `/api/*` to Railway for same-origin cookies.
+- **Production**: not yet determined (M4 scope).
+
+See `docs/staging-*.md` for staging setup details.

--- a/docs/backend-test-strategy.md
+++ b/docs/backend-test-strategy.md
@@ -4,7 +4,7 @@
 
 Langoose separates backend tests into:
 
-- `apps/api/tests/Langoose.Api.UnitTests`
+- `apps/api/tests/Langoose.Core.UnitTests`
 - `apps/api/tests/Langoose.Api.IntegrationTests`
 
 This split is intentional.

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -1,0 +1,336 @@
+# Domain Model
+
+This document describes the data model for Langoose. All entities live in
+`Langoose.Domain/Models/` and use `Guid` primary keys generated with
+`Guid.CreateVersion7()` (time-ordered for efficient B-tree indexing).
+Mapping tables use composite primary keys instead of surrogate IDs.
+
+## Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    DictionaryEntry ||--o{ EntryContext : has
+    DictionaryEntry }o--o| DictionaryEntry : "BaseEntryId (self-ref)"
+    DictionaryEntry }o--o{ DictionaryEntry : "EntryTranslation"
+    EntryContext }o--o{ EntryContext : "ContextTranslation"
+    UserDictionaryEntry }o--o| DictionaryEntry : references
+    UserDictionaryEntry ||--o{ UserEntryContext : has
+    UserProgress }o--|| DictionaryEntry : tracks
+    StudyEvent }o--|| DictionaryEntry : references
+    StudyEvent }o--o| EntryContext : tested_with
+    ContentFlag }o--|| DictionaryEntry : flags
+
+    DictionaryEntry {
+        guid Id PK
+        string Language
+        string Text
+        guid BaseEntryId FK "nullable, self-ref"
+        string GrammarLabel "nullable"
+        string PartOfSpeech
+        string Difficulty
+        bool IsPublic
+        Source Source
+        datetime CreatedAtUtc
+    }
+
+    EntryTranslation {
+        guid SourceEntryId PK_FK
+        guid TargetEntryId PK_FK
+    }
+
+    EntryContext {
+        guid Id PK
+        guid DictionaryEntryId FK
+        string Text
+        string Cloze
+        string Difficulty
+        double QualityScore
+        ContentOrigin Origin
+    }
+
+    ContextTranslation {
+        guid SourceContextId PK_FK
+        guid TargetContextId PK_FK
+    }
+
+    UserDictionaryEntry {
+        guid Id PK
+        guid UserId
+        guid DictionaryEntryId FK "nullable"
+        string RawText
+        string RawTranslation
+        string Language
+        EnrichmentStatus EnrichmentStatus
+        int EnrichmentAttempts
+        datetime EnrichmentNotBefore "nullable"
+        string Notes
+        string_arr Tags
+        UserEntryStatus Status
+        string CreatedByFlow
+        datetime CreatedAtUtc
+    }
+
+    UserEntryContext {
+        guid Id PK
+        guid UserDictionaryEntryId FK
+        string Text
+        string Cloze
+    }
+
+    UserProgress {
+        guid Id PK
+        guid UserId
+        guid DictionaryEntryId FK
+        double Stability
+        datetime DueAtUtc
+        int LapseCount
+        int SuccessCount
+        datetime LastSeenAtUtc "nullable"
+    }
+
+    StudyEvent {
+        guid Id PK
+        guid UserId
+        guid DictionaryEntryId FK
+        guid EntryContextId FK "nullable"
+        datetime AnsweredAtUtc
+        string SubmittedAnswer
+        string NormalizedAnswer
+        StudyVerdict Verdict
+        FeedbackCode FeedbackCode
+    }
+
+    ContentFlag {
+        guid Id PK
+        guid UserId
+        guid DictionaryEntryId FK
+        string Reason
+        string Details
+        datetime CreatedAtUtc
+    }
+
+    ImportRecord {
+        guid Id PK
+        guid UserId
+        string FileName
+        int TotalRows
+        int ImportedRows
+        int SkippedRows
+        datetime CreatedAtUtc
+    }
+```
+
+## Entities
+
+### DictionaryEntry
+
+A word or word form in any language. Base forms (lemmas) and derived forms
+(inflections, cases, tenses) live in the same table, linked by `BaseEntryId`.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| Id | Guid v7 | Primary key |
+| Language | string | Language code (e.g., "en", "ru") |
+| Text | string | The word or form (e.g., "book", "booked", "книга", "книгу") |
+| BaseEntryId | Guid? | FK to self. Null for base forms, points to lemma for derived forms. |
+| GrammarLabel | string? | Grammar description of this form: "past simple", "plural", "accusative". Null for base forms. |
+| PartOfSpeech | string | "noun", "verb", "phrase", etc. Meaningful on base forms. |
+| Difficulty | string | General difficulty (A1–B2) |
+| IsPublic | bool | `true` for curated base items, `false` for user-contributed until validated |
+| Source | enum | `Base` (curated) or `UserContributed` |
+| CreatedAtUtc | DateTimeOffset | |
+
+Indexed on `(Language, Text)`.
+
+Examples:
+- `("en", "book", null, null, "verb")` — base form
+- `("en", "booked", →book, "past simple", "verb")` — derived form
+- `("en", "books", →book, "plural", "noun")` — derived form
+- `("ru", "книга", null, null, "noun")` — base form
+- `("ru", "книгу", →книга, "accusative", "noun")` — derived form
+
+"book" as a noun and "book" as a verb are separate base entries (different
+PartOfSpeech).
+
+Derived forms serve two purposes:
+1. **Dedup lookup** — user types "книгу" → find entry → follow BaseEntryId → found
+2. **Context linking** — EntryContext links to the specific form, so ExpectedAnswer
+   and GrammarHint are derived from the entry rather than stored on the context
+
+### EntryTranslation
+
+Links base forms across languages as word-level translation hints. Stored in both
+directions for simple querying.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| SourceEntryId | Guid | FK to DictionaryEntry (base form) |
+| TargetEntryId | Guid | FK to DictionaryEntry (base form) |
+
+PK: `(SourceEntryId, TargetEntryId)`. Stored bidirectionally — if (A→B) exists,
+(B→A) also exists.
+
+Examples:
+- ("book" en verb) ↔ ("забронировать" ru)
+- ("book" en noun) ↔ ("книга" ru)
+- ("book" en noun) ↔ ("книжка" ru)
+
+These provide the word-level glosses shown on study cards regardless of which
+specific context is being tested.
+
+### EntryContext
+
+A learning context for a specific entry form. Contains an English (or any language)
+sentence with a cloze gap. The expected answer and grammar hint are derived from the
+linked DictionaryEntry.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| Id | Guid v7 | |
+| DictionaryEntryId | Guid | FK to DictionaryEntry (the specific form being tested) |
+| Text | string | Full sentence (e.g., "She booked the room yesterday.") |
+| Cloze | string | Sentence with gap (e.g., "She ____ the room yesterday.") |
+| Difficulty | string | Per-context difficulty (A1–B2) |
+| QualityScore | double | Content quality score |
+| Origin | enum | `Dataset` (curated) or `Ai` (generated) |
+
+A base entry typically has 1–3 contexts across its forms, providing variety for
+study card rotation.
+
+**Derived fields** (not stored, computed at query time):
+- `ExpectedAnswer` = linked DictionaryEntry.Text
+- `GrammarHint` = linked DictionaryEntry.GrammarLabel
+
+### ContextTranslation
+
+Links two EntryContexts that are translations of the same sentence. Same pattern
+as EntryTranslation — stored bidirectionally.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| SourceContextId | Guid | FK to EntryContext |
+| TargetContextId | Guid | FK to EntryContext |
+
+PK: `(SourceContextId, TargetContextId)`.
+
+Example:
+- EntryContext("She booked the room.", linked to "booked" en)
+  ↔ EntryContext("Она забронировала комнату.", linked to "забронировала" ru)
+
+When studying English, the English context's Cloze is shown and the Russian
+context's Text is the sentence-level hint. When studying Russian (future), the
+roles reverse.
+
+### UserDictionaryEntry
+
+A per-user dictionary entry. Owns the enrichment lifecycle (pending/failed state).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| Id | Guid v7 | |
+| UserId | Guid | |
+| DictionaryEntryId | Guid? | FK to DictionaryEntry. Null while pending enrichment. |
+| RawText | string | What the user typed as the word |
+| RawTranslation | string | What the user typed as the translation |
+| Language | string | Target language (e.g., "ru") |
+| EnrichmentStatus | enum | `Pending`, `Enriched`, or `Failed` |
+| EnrichmentAttempts | int | Retry counter |
+| EnrichmentNotBefore | DateTimeOffset? | Backoff scheduling |
+| Notes | string | User's private notes |
+| Tags | string[] | User's private tags |
+| Status | enum | `Active` or `Archived` |
+| CreatedByFlow | string | "quick-add", "csv-import" |
+| CreatedAtUtc | DateTimeOffset | |
+
+When enrichment succeeds, a DictionaryEntry is created (or found),
+`DictionaryEntryId` is set, and status becomes `Enriched`. When enrichment fails
+after max retries, the item is marked `Failed` and `DictionaryEntryId` stays null.
+
+### UserEntryContext
+
+A private learning context created by the user. Linked to UserDictionaryEntry.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| Id | Guid v7 | |
+| UserDictionaryEntryId | Guid | FK to UserDictionaryEntry |
+| Text | string | Full sentence |
+| Cloze | string | Sentence with gap |
+
+User contexts can also have translations via the same ContextTranslation pattern
+if the user provides them.
+
+### UserProgress
+
+Spaced repetition state per (user, dictionary entry). Created lazily when a
+DictionaryEntry first appears in a user's study session.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| Id | Guid v7 | |
+| UserId | Guid | |
+| DictionaryEntryId | Guid | FK to DictionaryEntry (base form) |
+| Stability | double | Affects rescheduling interval |
+| DueAtUtc | DateTimeOffset | When the item is next due |
+| LapseCount | int | Incorrect answer count |
+| SuccessCount | int | Correct/almost-correct count |
+| LastSeenAtUtc | DateTimeOffset? | |
+
+Unique constraint on `(UserId, DictionaryEntryId)`.
+
+### StudyEvent
+
+Records each answer attempt for analytics and history.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| Id | Guid v7 | |
+| UserId | Guid | |
+| DictionaryEntryId | Guid | FK to DictionaryEntry |
+| EntryContextId | Guid? | FK to EntryContext (which context was tested) |
+| AnsweredAtUtc | DateTimeOffset | |
+| SubmittedAnswer | string | |
+| NormalizedAnswer | string | |
+| Verdict | enum | `Correct`, `AlmostCorrect`, `Incorrect` |
+| FeedbackCode | enum | `ExactMatch`, `MinorTypo`, `MeaningMismatch`, etc. |
+
+### ContentFlag
+
+Reports quality issues with shared content.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| Id | Guid v7 | |
+| UserId | Guid | |
+| DictionaryEntryId | Guid | FK to DictionaryEntry |
+| Reason | string | |
+| Details | string | |
+| CreatedAtUtc | DateTimeOffset | |
+
+### ImportRecord
+
+Tracks CSV import history (file name, row counts, timestamps).
+
+## Enums
+
+| Enum | Values | Used on |
+|------|--------|---------|
+| EnrichmentStatus | Pending, Enriched, Failed | UserDictionaryEntry |
+| Source | Base, UserContributed | DictionaryEntry |
+| UserEntryStatus | Active, Archived | UserDictionaryEntry |
+| ContentOrigin | Dataset, Ai | EntryContext |
+| StudyVerdict | Correct, AlmostCorrect, Incorrect | StudyEvent |
+| FeedbackCode | ExactMatch, AcceptedVariant, MissingArticle, InflectionMismatch, MinorTypo, MeaningMismatch | StudyEvent |
+
+## Key Indexes
+
+| Table | Index | Purpose |
+|-------|-------|---------|
+| DictionaryEntry | `(Language, Text)` | Fast lookup by word |
+| DictionaryEntry | `BaseEntryId` | Find all forms of a base entry |
+| EntryTranslation | PK `(SourceEntryId, TargetEntryId)` | Translation lookup |
+| EntryContext | `DictionaryEntryId` | Find contexts for an entry |
+| ContextTranslation | PK `(SourceContextId, TargetContextId)` | Context translation lookup |
+| UserDictionaryEntry | `UserId` | User's dictionary |
+| UserDictionaryEntry | `EnrichmentStatus` | Worker polling |
+| UserProgress | Unique `(UserId, DictionaryEntryId)` | One progress per user per entry |

--- a/docs/enrichment-pipeline.md
+++ b/docs/enrichment-pipeline.md
@@ -1,0 +1,168 @@
+# Enrichment Pipeline
+
+The enrichment pipeline generates study content for dictionary entries: learning
+contexts with cloze gaps, sentence translations, grammar labels, difficulty ratings,
+and morphological form data.
+
+## How It Works
+
+```
+User adds "book" + "книгу"
+         │
+         ▼
+┌──────────────────────────────┐
+│  DictionaryService           │
+│  1. Find DictionaryEntry     │
+│     ("книгу", ru)            │
+│  2. Follow BaseEntryId       │
+│     → ("книга", ru)          │
+│  3. Check EntryTranslation   │
+│     → any linked en entry?   │
+└─────────┬────────────────────┘
+          │
+     ┌────┴────┐
+     │ Found?  │
+     └────┬────┘
+    yes   │   no
+     │    │    │
+     ▼    │    ▼
+ Link to  │  Create UserDictionaryEntry
+ existing │  (Pending, DictionaryEntryId = null)
+ entry    │        │
+     │         │
+     ▼         ▼
+  Done     Worker picks it up
+           (background, batched)
+                │
+                ▼
+      ┌──────────────────────┐
+      │ IEnrichmentProvider   │
+      │ .EnrichBatchAsync()   │
+      └────────┬──────────────┘
+               │
+               ▼
+      ┌─────────────────┐
+      │  LLM (Gemini)   │
+      │  or Local        │
+      │  fallback        │
+      └────────┬────────┘
+               │
+               ▼
+      Create DictionaryEntries (base + forms)
+      Create EntryTranslations (bidirectional)
+      Create EntryContexts + ContextTranslations
+      Link UserDictionaryEntry → DictionaryEntry
+      Status → Enriched
+```
+
+## Provider Architecture
+
+`IEnrichmentProvider` is defined in Domain with a batch-oriented interface:
+
+```
+Task<EnrichmentResult[]> EnrichBatchAsync(
+    EnrichmentRequest[] batch,
+    CancellationToken cancellationToken)
+```
+
+Two implementations in Core:
+
+- **LocalEnrichmentProvider** — static lexicon with a handful of entries. Used as
+  fallback when AI enrichment is disabled or fails.
+- **GeminiEnrichmentProvider** — calls Gemini Flash REST API. Sends one batched
+  prompt with multiple terms, receives a structured JSON array response.
+
+The Worker resolves `IEnrichmentProvider` from DI. When `Features.EnableAiEnrichment`
+is true and the Gemini API key is configured, it uses Gemini; otherwise Local.
+
+## What the LLM Produces
+
+For each term in a batch, the LLM returns:
+
+| Field | Example |
+|-------|---------|
+| Base form (target language) | "книга" |
+| Derived forms | ["книги", "книгу", "книге", "книгой"] with grammar labels |
+| Base form (source language) | "book" |
+| Derived forms (source) | ["booked", "books", "booking"] with grammar labels |
+| Part of speech | "noun" |
+| General difficulty | "A1" |
+| Learning contexts (1–3) | See below |
+
+Each learning context includes a bilingual sentence pair:
+
+| Field | Example |
+|-------|---------|
+| Source sentence | "She bought a new book yesterday." |
+| Source cloze | "She bought a new ____ yesterday." |
+| Source form | "book" (links to the specific DictionaryEntry form) |
+| Target sentence | "Она купила новую книгу вчера." |
+| Target form | "книгу" (links to the specific DictionaryEntry form) |
+| Difficulty | "A1" |
+
+The expected answer is the source form's Text. The grammar hint is the source
+form's GrammarLabel. Neither is stored on the context — both are derived from
+the linked DictionaryEntry.
+
+## Background Worker
+
+`EnrichmentBackgroundService` runs in the Worker project:
+
+1. **Poll**: query UserDictionaryEntries where `EnrichmentStatus = Pending` and
+   `EnrichmentNotBefore` is null or in the past. Order by `CreatedAtUtc`.
+   Limit to batch size (configurable, default 10).
+2. **Deduplicate**: for each item, check if a matching DictionaryEntry already
+   exists by looking up the raw translation text as a form. If found, skip
+   enrichment and link directly.
+3. **Enrich**: call `IEnrichmentProvider.EnrichBatchAsync()` with remaining items.
+4. **Persist**: for each successful result:
+   - Create DictionaryEntry base forms + derived forms (both languages)
+   - Create EntryTranslation links (bidirectional)
+   - Create EntryContext for each learning context (linked to the specific form)
+   - Create paired EntryContext in the target language
+   - Create ContextTranslation links (bidirectional)
+   - Set `UserDictionaryEntry.DictionaryEntryId`, status to Enriched
+5. **Handle failures**: increment `EnrichmentAttempts`. If over max retries, mark
+   Failed. On rate-limit responses (HTTP 429), set `EnrichmentNotBefore` with
+   exponential backoff.
+6. **Sleep**: wait for the configured poll interval (default 5 seconds), then repeat.
+
+The worker creates a new DI scope per poll cycle since `AppDbContext` is scoped.
+
+## Form-Based Deduplication
+
+When the LLM enriches a term, it creates DictionaryEntry rows for base forms and
+derived forms in both languages. Derived forms point back to their base via
+`BaseEntryId`.
+
+Over time, this builds a lookup index:
+
+```
+DictionaryEntry("книгу", ru, base→"книга")
+DictionaryEntry("книге", ru, base→"книга")
+DictionaryEntry("книга", ru, base=null)
+  ← EntryTranslation →
+DictionaryEntry("book", en, base=null)
+```
+
+When a second user adds "book" + "книге", the lookup finds the existing
+DictionaryEntry("книге", ru) → base → EntryTranslation → "book" (en).
+No LLM call needed.
+
+## Rate Limiting
+
+- **Per-user**: maximum items per hour/day (configurable). Prevents abuse.
+- **API-level**: Gemini free-tier limits (requests per minute/day). In-memory
+  sliding window in the background worker.
+- **Backoff**: on HTTP 429 or 5xx from Gemini, the worker sets
+  `UserDictionaryEntry.EnrichmentNotBefore` with exponential delay. Retried
+  later, not counted as a permanent failure.
+- **Permanent failure**: after max retries (configurable, default 3), the item
+  is marked `Failed`.
+
+## Feature Flag
+
+`Features.EnableAiEnrichment` in `appsettings.json` controls whether the Worker
+processes pending items. When disabled, the sync enrichment path (using
+LocalEnrichmentProvider) is used for base item seeding. User-added items stay
+Pending until the flag is enabled.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,132 @@
+# Getting Started
+
+## Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download)
+- [Node.js 20+](https://nodejs.org/) and npm
+- [Docker](https://www.docker.com/) and Docker Compose (for PostgreSQL)
+- [Git](https://git-scm.com/)
+
+## Quick Start
+
+### 1. Start the database
+
+```bash
+docker compose up -d postgres
+```
+
+This starts PostgreSQL on port 5432 with two databases: `langoose_app` and
+`langoose_auth`. Credentials are in `docker-compose.yml`.
+
+### 2. Run the API
+
+```bash
+dotnet run --project apps/api/src/Langoose.Api/Langoose.Api.csproj
+```
+
+On first run, the API auto-applies migrations and seeds base dictionary content.
+The API listens on `http://localhost:5000` by default.
+
+### 3. Run the frontend
+
+```bash
+cd apps/web
+npm install
+npm run dev
+```
+
+The frontend runs on `http://localhost:5173` and proxies API calls to port 5000.
+
+### 4. Run the Worker (optional)
+
+```bash
+dotnet run --project apps/api/src/Langoose.Worker/Langoose.Worker.csproj
+```
+
+The Worker processes background enrichment. Only needed when testing enrichment
+features. Requires `Features.EnableAiEnrichment = true` in appsettings.
+
+## Running with Docker Compose
+
+To run everything containerized:
+
+```bash
+docker compose up -d postgres
+docker compose up -d api --build
+docker compose up -d web --build
+```
+
+## Build and Test
+
+### Backend
+
+```bash
+# Build
+dotnet build apps/api/Langoose.sln /p:RestoreConfigFile=apps/api/NuGet.Config
+
+# Unit tests
+dotnet test apps/api/tests/Langoose.Core.UnitTests/Langoose.Core.UnitTests.csproj \
+  /p:RestoreConfigFile=apps/api/NuGet.Config
+
+# Integration tests
+dotnet test apps/api/tests/Langoose.Api.IntegrationTests/Langoose.Api.IntegrationTests.csproj \
+  /p:RestoreConfigFile=apps/api/NuGet.Config
+```
+
+### Frontend
+
+```bash
+cd apps/web
+npm run build    # production build
+npm run test     # run tests
+```
+
+### E2E Tests
+
+Requires the whole app running via Docker Compose:
+
+```bash
+docker compose --profile e2e up --build e2e
+```
+
+## Migrations
+
+App database:
+
+```bash
+dotnet ef migrations add <MigrationName> \
+  --project apps/api/src/Langoose.Data \
+  --startup-project apps/api/src/Langoose.Api
+```
+
+Auth database:
+
+```bash
+dotnet ef migrations add <MigrationName> \
+  --project apps/api/src/Langoose.Auth.Data \
+  --startup-project apps/api/src/Langoose.Api
+```
+
+Migrations are auto-applied on startup locally. For staging/production, use
+`Langoose.DbTool` (see `docs/staging-db-operations.md`).
+
+## Project Structure
+
+See [architecture.md](architecture.md) for the full project map and onion layer
+description.
+
+## Configuration
+
+The API reads configuration from `appsettings.json`:
+
+| Section | Key settings |
+|---------|-------------|
+| ConnectionStrings | AppDatabase, AuthDatabase |
+| Cors | AllowedOrigins |
+| ForwardedHeaders | Enabled, KnownProxies |
+| Features | EnableAiEnrichment |
+| Enrichment | PollIntervalSeconds, BatchSize, MaxRetries |
+| Gemini | ApiKey, Model, MaxOutputTokens |
+
+For local development, the defaults in `appsettings.json` work with the Docker
+Compose PostgreSQL setup.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -52,13 +52,20 @@ Complete the core product loop for a returning learner.
 - Each base entry includes: English term, Russian glosses, example sentences with cloze gaps, difficulty, part of speech, accepted variants
 - Iterate on base content quality through the existing content flagging system
 
-**AI-powered enrichment**
+**Domain model and architecture (#68)**
+
+- Restructure the solution into onion architecture (Domain, Core, Data, Api, Worker)
+- Replace the flat DictionaryItem model with SharedItem (enriched content), UserItem (per-user entries), Gloss/GlossSurfaceForm (language-agnostic morphological normalization)
+- Sentence-based study cards with per-sentence difficulty, grammar hints, and expected answer forms
+- Services use domain models only; DTOs map in the presentation layer
+
+**AI-powered enrichment (#56, depends on #68)**
 
 - Async background enrichment for custom words added by users
-- Shared enrichment layer: if a word is already enriched, reuse the result for all users
-- User-provided custom context (own sentences, translations) takes priority and remains private per user
-- Three-state visibility: custom context provided (ready), AI-enriched (ready), pending enrichment (hidden from study cards)
-- Provider: best available free-tier LLM (currently Gemini Flash)
+- SharedItem is the shared content layer: only enriched/validated content lives there, reusable across users
+- UserItem owns the enrichment lifecycle (pending/failed state); linked to SharedItem once enriched
+- GlossSurfaceForm dedup: morphological variants resolved to canonical form by LLM, cached for instant lookup
+- Provider: best available free-tier LLM (currently Gemini Flash), abstracted behind IEnrichmentProvider
 - Batch processing within external API limits for CSV imports and bulk operations
 - Rate limiting to stay within API quotas and prevent abuse
 

--- a/docs/study-system.md
+++ b/docs/study-system.md
@@ -1,0 +1,135 @@
+# Study System
+
+The study system presents vocabulary in context through sentence-based flashcards
+with spaced repetition scheduling.
+
+## Study Cards
+
+The learning unit is a **sentence with a gap** (EntryContext), not an isolated word.
+Each card presents a complete learning context:
+
+```
+┌─────────────────────────────────────────────┐
+│                                             │
+│  She ____ the room yesterday.               │
+│                                             │
+│  ─────────────────────────────────────────  │
+│  Она забронировала комнату вчера.            │
+│                                             │
+│  Translations: забронировать                │
+│  Form: past simple                          │
+│  Difficulty: B1                             │
+│                                             │
+│  Your answer: [          ]                  │
+│                                             │
+└─────────────────────────────────────────────┘
+```
+
+### Card Content
+
+| Field | Source | Description |
+|-------|--------|-------------|
+| Cloze | EntryContext.Cloze | Sentence with `____` gap |
+| Sentence translation | Paired EntryContext.Text (via ContextTranslation) | Full sentence in the user's language |
+| Translations | EntryTranslation → target language base entries | Word-level glosses |
+| Grammar hint | DictionaryEntry.GrammarLabel (linked from EntryContext) | Expected grammatical form |
+| Expected answer | DictionaryEntry.Text (linked from EntryContext) | The exact form to type |
+| Difficulty | EntryContext.Difficulty | Per-context difficulty (A1–B2) |
+
+The grammar hint and expected answer are not stored on the context — they are
+derived from the linked DictionaryEntry (the specific form being tested).
+
+### Context Rotation
+
+Each base entry can have multiple EntryContexts across its forms. The study system
+rotates through them so the learner sees the word in different contexts and
+grammatical forms.
+
+## Card Selection
+
+### Studyable Pool
+
+A user's study pool consists of:
+
+1. **Public DictionaryEntries** (base forms) — the curated base dictionary.
+2. **User's enriched custom entries** — DictionaryEntries linked from the user's
+   UserDictionaryEntries where `DictionaryEntryId` is not null.
+
+Items excluded from the pool:
+- UserDictionaryEntries with `EnrichmentStatus = Pending` or `Failed`
+- DictionaryEntries with no EntryContexts
+
+### Selection Algorithm
+
+1. Build the studyable pool (public + user's enriched custom base entries).
+2. Join with UserProgress for scheduling data.
+3. Create UserProgress lazily for entries encountered for the first time.
+4. Order by `DueAtUtc` ascending, then `SuccessCount` ascending (newer items first).
+5. Bias toward custom items when they are underrepresented in the pool.
+6. Pick a base entry, then pick an EntryContext for one of its forms (rotating).
+7. Optionally include UserEntryContexts if the user has added their own.
+
+## Answer Evaluation
+
+The user's answer is compared against the expected answer — the `Text` field of
+the DictionaryEntry linked to the EntryContext.
+
+### Verdicts
+
+| Verdict | When | FeedbackCode |
+|---------|------|-------------|
+| Correct | Exact match or very close | ExactMatch |
+| AlmostCorrect | Missing article (a/an/the) | MissingArticle |
+| AlmostCorrect | Inflection variant | InflectionMismatch |
+| AlmostCorrect | Minor typo (Levenshtein distance 1–2) | MinorTypo |
+| Incorrect | Substantially wrong answer | MeaningMismatch |
+
+Evaluation uses `TextNormalizer` for:
+- Case-insensitive comparison
+- Whitespace and punctuation normalization
+- Levenshtein distance for typo tolerance (threshold: 1 char for short words,
+  2 chars for 7+ character words)
+- Article stripping (a/an/the)
+
+### Tracking
+
+Each answer is recorded as a `StudyEvent` with the `EntryContextId` that was
+tested. This enables per-context analytics — identifying which contexts or
+grammatical forms are particularly difficult.
+
+## Spaced Repetition
+
+### UserProgress
+
+Tracks study state per (user, base DictionaryEntry). Created lazily on first
+encounter.
+
+| Field | Description |
+|-------|-------------|
+| Stability | Affects interval length. Increases on correct, decreases on incorrect. |
+| DueAtUtc | When the entry is next due for review. |
+| LapseCount | Total incorrect answers. |
+| SuccessCount | Total correct/almost-correct answers. |
+| LastSeenAtUtc | Timestamp of last study attempt. |
+
+### Current Scheduler
+
+The scheduler uses fixed stability increments:
+
+| Verdict | Stability Change | Next Interval |
+|---------|-----------------|---------------|
+| Correct | +0.15 (max 0.95) | 12h x SuccessCount |
+| AlmostCorrect | +0.08 (max 0.85) | 8h x SuccessCount |
+| Incorrect | -0.12 (min 0.20) | 10 minutes |
+
+This is a placeholder scheduler. M3 plans adoption of FSRS (Free Spaced
+Repetition Scheduler) for more sophisticated interval calculation.
+
+## Dashboard
+
+| Metric | Calculation |
+|--------|-------------|
+| Total items | Public base entries + user's enriched entries |
+| Due now | UserProgress rows where DueAtUtc <= now |
+| New items | Entries in pool with no UserProgress row |
+| Studied today | StudyEvents in the last 24 hours |


### PR DESCRIPTION
## Summary

- Rewrite 7 agent guidance docs for the planned domain model redesign (#68) and enrichment pipeline (#56)
- Create 6 human-readable docs: architecture overview, domain model reference (with ER diagram), enrichment pipeline, study system, getting started guide, API reference
- Update roadmap and test strategy for new project layout
- Add workflow rules for GitHub sub-issue linking and issue assignment

## Domain model (documented, not yet implemented)

- **DictionaryEntry** — word or form in any language; base forms and derived forms in the same table linked by `BaseEntryId`
- **EntryTranslation** — links base forms across languages (bidirectional, composite PK)
- **EntryContext** — learning context (sentence + cloze) linked to a specific form; ExpectedAnswer and GrammarHint derived from the linked entry
- **ContextTranslation** — links paired contexts across languages (bidirectional, composite PK)
- **UserDictionaryEntry** — per-user entry owning the enrichment lifecycle (pending/enriched/failed)

## Docs updated

| Doc | Type | Key changes |
|-----|------|-------------|
| docs/architecture.md | New | System overview, onion layers, project map, deployment |
| docs/domain-model.md | New | Entity reference, ER diagram, field tables, indexes |
| docs/enrichment-pipeline.md | New | End-to-end enrichment flow, provider architecture |
| docs/study-system.md | New | Sentence-based cards, evaluation, scheduling, dashboard |
| docs/getting-started.md | New | Prerequisites, dev setup, build/test commands |
| docs/api-reference.md | New | Endpoint catalog with request/response examples |
| docs/roadmap.md | Updated | Domain rework epic (#68) added to M2 scope |
| docs/backend-test-strategy.md | Updated | Rename unit test project to Core.UnitTests |
| docs/agent/* (7 files) | Rewritten | All agent guidance updated for new model and naming |
| CLAUDE.md + AGENTS.md | Updated | Guidance index, workflow rules |

## Test plan

- [ ] All doc links validated via sync-rules
- [ ] No stale references to removed entities (DictionaryItem, ReviewState, SharedItem, etc.)
- [ ] AGENTS.md synced with CLAUDE.md

Closes #73