### PR TITLE
Restructure solution into onion architecture

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,16 @@
       "Skill(what-next)",
       "Skill(what-next:*)",
       "Bash(xargs grep:*)",
-      "Bash(git stash:*)"
+      "Bash(git stash:*)",
+      "Bash(dotnet new:*)",
+      "Bash(dotnet add:*)",
+      "Bash(rm Class1.cs)",
+      "Bash(dotnet build:*)",
+      "Bash(dotnet test:*)",
+      "Bash(docker compose:*)",
+      "Bash(dotnet format:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh run:*)"
     ]
   }
 }

--- a/.codex/skills/langoose-architecture/SKILL.md
+++ b/.codex/skills/langoose-architecture/SKILL.md
@@ -27,7 +27,7 @@ Use this skill when the task is about architecture and project boundaries, not j
 
 - Build the affected solution or projects explicitly after changing project boundaries.
 - Run the current backend tests:
-  - `dotnet test apps/api/tests/Langoose.Api.UnitTests/Langoose.Api.UnitTests.csproj /p:RestoreConfigFile=apps/api/NuGet.Config`
+  - `dotnet test apps/api/tests/Langoose.Core.UnitTests/Langoose.Core.UnitTests.csproj /p:RestoreConfigFile=apps/api/NuGet.Config`
   - `dotnet test apps/api/tests/Langoose.Api.IntegrationTests/Langoose.Api.IntegrationTests.csproj /p:RestoreConfigFile=apps/api/NuGet.Config`
 - If Docker or startup wiring changed, verify the live startup path before declaring the architecture work complete.
 - If the refactor created new projects or moved many files, check for mixed line endings before finalizing.

--- a/.codex/skills/langoose-efcore-structure/SKILL.md
+++ b/.codex/skills/langoose-efcore-structure/SKILL.md
@@ -38,7 +38,7 @@ Use this skill when the task is about EF Core structure rather than day-to-day f
 ## Validation
 
 - Run the current backend tests:
-  - `dotnet test apps/api/tests/Langoose.Api.UnitTests/Langoose.Api.UnitTests.csproj /p:RestoreConfigFile=apps/api/NuGet.Config`
+  - `dotnet test apps/api/tests/Langoose.Core.UnitTests/Langoose.Core.UnitTests.csproj /p:RestoreConfigFile=apps/api/NuGet.Config`
   - `dotnet test apps/api/tests/Langoose.Api.IntegrationTests/Langoose.Api.IntegrationTests.csproj /p:RestoreConfigFile=apps/api/NuGet.Config`
 - If project boundaries changed, also build the affected projects or solution explicitly.
 - If startup or migrations wiring changed, verify the live container or local startup path before declaring the structure work complete.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,10 +122,10 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Restore unit tests
-        run: dotnet restore apps/api/tests/Langoose.Api.UnitTests/Langoose.Api.UnitTests.csproj /p:RestoreConfigFile=${{ github.workspace }}/apps/api/NuGet.Config
+        run: dotnet restore apps/api/tests/Langoose.Core.UnitTests/Langoose.Core.UnitTests.csproj /p:RestoreConfigFile=${{ github.workspace }}/apps/api/NuGet.Config
 
       - name: Run backend unit tests
-        run: dotnet test apps/api/tests/Langoose.Api.UnitTests/Langoose.Api.UnitTests.csproj --configuration Release --no-restore /p:RestoreConfigFile=${{ github.workspace }}/apps/api/NuGet.Config
+        run: dotnet test apps/api/tests/Langoose.Core.UnitTests/Langoose.Core.UnitTests.csproj --configuration Release --no-restore /p:RestoreConfigFile=${{ github.workspace }}/apps/api/NuGet.Config
 
   backend-integration-tests:
     name: Backend Integration Tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@
 - Run the smallest relevant build, test, and acceptance checks for the change.
 - Prefer containerized whole-app validation when the change affects startup, persistence, auth, or cross-app behavior.
 - If a validation lane is blocked or fails, say so plainly and do not report it as passing by inference.
-- When a change renames or moves a project, Dockerfile, or test assembly, update the affected GitHub Actions workflows in the same change.
+- When a change renames or moves a project, Dockerfile, or test assembly, update the affected GitHub Actions workflows, contributor commands, and repo guidance docs in the same change.
 
 ## Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@
 - Run the smallest relevant build, test, and acceptance checks for the change.
 - Prefer containerized whole-app validation when the change affects startup, persistence, auth, or cross-app behavior.
 - If a validation lane is blocked or fails, say so plainly and do not report it as passing by inference.
+- When a change renames or moves a project, Dockerfile, or test assembly, update the affected GitHub Actions workflows in the same change.
 
 ## Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,11 @@
 ## Project Shape
 
 - `apps/api` is the backend boundary.
-- `apps/api/src/Langoose.Api` contains the ASP.NET Core API.
-- `apps/api/src/Langoose.Domain` contains shared domain models and abstractions.
+- `apps/api/src/Langoose.Domain` contains domain models, enums, constants, and service interfaces.
+- `apps/api/src/Langoose.Core` contains service implementations and utilities.
 - `apps/api/src/Langoose.Data` contains app persistence and seeding.
+- `apps/api/src/Langoose.Api` contains controllers, DTOs, middleware, and DI setup.
+- `apps/api/src/Langoose.Worker` contains the background processing host.
 - `apps/api/src/Langoose.Auth.Data` contains auth persistence.
 - `apps/api/tests` contains backend unit and integration tests.
 - `apps/web` contains the React 19 + TypeScript + Vite frontend.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@
 - Run the smallest relevant build, test, and acceptance checks for the change.
 - Prefer containerized whole-app validation when the change affects startup, persistence, auth, or cross-app behavior.
 - If a validation lane is blocked or fails, say so plainly and do not report it as passing by inference.
-- When a change renames or moves a project, Dockerfile, or test assembly, update the affected GitHub Actions workflows in the same change.
+- When a change renames or moves a project, Dockerfile, or test assembly, update the affected GitHub Actions workflows, contributor commands, and repo guidance docs in the same change.
 
 ## Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@
 - Run the smallest relevant build, test, and acceptance checks for the change.
 - Prefer containerized whole-app validation when the change affects startup, persistence, auth, or cross-app behavior.
 - If a validation lane is blocked or fails, say so plainly and do not report it as passing by inference.
+- When a change renames or moves a project, Dockerfile, or test assembly, update the affected GitHub Actions workflows in the same change.
 
 ## Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,9 +3,11 @@
 ## Project Shape
 
 - `apps/api` is the backend boundary.
-- `apps/api/src/Langoose.Api` contains the ASP.NET Core API.
-- `apps/api/src/Langoose.Domain` contains shared domain models and abstractions.
+- `apps/api/src/Langoose.Domain` contains domain models, enums, constants, and service interfaces.
+- `apps/api/src/Langoose.Core` contains service implementations and utilities.
 - `apps/api/src/Langoose.Data` contains app persistence and seeding.
+- `apps/api/src/Langoose.Api` contains controllers, DTOs, middleware, and DI setup.
+- `apps/api/src/Langoose.Worker` contains the background processing host.
 - `apps/api/src/Langoose.Auth.Data` contains auth persistence.
 - `apps/api/tests` contains backend unit and integration tests.
 - `apps/web` contains the React 19 + TypeScript + Vite frontend.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Common backend checks:
 
 ```powershell
 dotnet build apps/api/Langoose.sln /p:RestoreConfigFile=apps/api/NuGet.Config
-dotnet test apps/api/tests/Langoose.Api.UnitTests/Langoose.Api.UnitTests.csproj /p:RestoreConfigFile=apps/api/NuGet.Config
+dotnet test apps/api/tests/Langoose.Core.UnitTests/Langoose.Core.UnitTests.csproj /p:RestoreConfigFile=apps/api/NuGet.Config
 dotnet test apps/api/tests/Langoose.Api.IntegrationTests/Langoose.Api.IntegrationTests.csproj /p:RestoreConfigFile=apps/api/NuGet.Config
 ```
 

--- a/apps/api/Directory.Build.props
+++ b/apps/api/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+</Project>

--- a/apps/api/Langoose.sln
+++ b/apps/api/Langoose.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
 VisualStudioVersion = 18.4.11612.150
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -14,9 +14,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Langoose.DbTool", "src\Lang
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Langoose.Api.UnitTests", "tests\Langoose.Api.UnitTests\Langoose.Api.UnitTests.csproj", "{45A146D3-14B0-475C-AD61-CE2A4773655C}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Langoose.Api.IntegrationTests", "tests\Langoose.Api.IntegrationTests\Langoose.Api.IntegrationTests.csproj", "{0E739DFC-955A-4B2B-885D-1D62E59A08A3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Langoose.Core", "src\Langoose.Core\Langoose.Core.csproj", "{63C80251-875D-4C13-BF94-FFC59CDDBACF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Langoose.Worker", "src\Langoose.Worker\Langoose.Worker.csproj", "{6155A544-22DA-4A25-AB51-12131109BA2C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Langoose.Core.UnitTests", "tests\Langoose.Core.UnitTests\Langoose.Core.UnitTests.csproj", "{9814E9E8-7CE3-41BD-8D34-10C3994DC953}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -88,18 +92,6 @@ Global
 		{7F52A899-3EF9-4E68-92A6-8DD2429FD2E6}.Release|x64.Build.0 = Release|Any CPU
 		{7F52A899-3EF9-4E68-92A6-8DD2429FD2E6}.Release|x86.ActiveCfg = Release|Any CPU
 		{7F52A899-3EF9-4E68-92A6-8DD2429FD2E6}.Release|x86.Build.0 = Release|Any CPU
-		{45A146D3-14B0-475C-AD61-CE2A4773655C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{45A146D3-14B0-475C-AD61-CE2A4773655C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{45A146D3-14B0-475C-AD61-CE2A4773655C}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{45A146D3-14B0-475C-AD61-CE2A4773655C}.Debug|x64.Build.0 = Debug|Any CPU
-		{45A146D3-14B0-475C-AD61-CE2A4773655C}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{45A146D3-14B0-475C-AD61-CE2A4773655C}.Debug|x86.Build.0 = Debug|Any CPU
-		{45A146D3-14B0-475C-AD61-CE2A4773655C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{45A146D3-14B0-475C-AD61-CE2A4773655C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{45A146D3-14B0-475C-AD61-CE2A4773655C}.Release|x64.ActiveCfg = Release|Any CPU
-		{45A146D3-14B0-475C-AD61-CE2A4773655C}.Release|x64.Build.0 = Release|Any CPU
-		{45A146D3-14B0-475C-AD61-CE2A4773655C}.Release|x86.ActiveCfg = Release|Any CPU
-		{45A146D3-14B0-475C-AD61-CE2A4773655C}.Release|x86.Build.0 = Release|Any CPU
 		{0E739DFC-955A-4B2B-885D-1D62E59A08A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0E739DFC-955A-4B2B-885D-1D62E59A08A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0E739DFC-955A-4B2B-885D-1D62E59A08A3}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -112,12 +104,48 @@ Global
 		{0E739DFC-955A-4B2B-885D-1D62E59A08A3}.Release|x64.Build.0 = Release|Any CPU
 		{0E739DFC-955A-4B2B-885D-1D62E59A08A3}.Release|x86.ActiveCfg = Release|Any CPU
 		{0E739DFC-955A-4B2B-885D-1D62E59A08A3}.Release|x86.Build.0 = Release|Any CPU
+		{63C80251-875D-4C13-BF94-FFC59CDDBACF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63C80251-875D-4C13-BF94-FFC59CDDBACF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63C80251-875D-4C13-BF94-FFC59CDDBACF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{63C80251-875D-4C13-BF94-FFC59CDDBACF}.Debug|x64.Build.0 = Debug|Any CPU
+		{63C80251-875D-4C13-BF94-FFC59CDDBACF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{63C80251-875D-4C13-BF94-FFC59CDDBACF}.Debug|x86.Build.0 = Debug|Any CPU
+		{63C80251-875D-4C13-BF94-FFC59CDDBACF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63C80251-875D-4C13-BF94-FFC59CDDBACF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63C80251-875D-4C13-BF94-FFC59CDDBACF}.Release|x64.ActiveCfg = Release|Any CPU
+		{63C80251-875D-4C13-BF94-FFC59CDDBACF}.Release|x64.Build.0 = Release|Any CPU
+		{63C80251-875D-4C13-BF94-FFC59CDDBACF}.Release|x86.ActiveCfg = Release|Any CPU
+		{63C80251-875D-4C13-BF94-FFC59CDDBACF}.Release|x86.Build.0 = Release|Any CPU
+		{6155A544-22DA-4A25-AB51-12131109BA2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6155A544-22DA-4A25-AB51-12131109BA2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6155A544-22DA-4A25-AB51-12131109BA2C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6155A544-22DA-4A25-AB51-12131109BA2C}.Debug|x64.Build.0 = Debug|Any CPU
+		{6155A544-22DA-4A25-AB51-12131109BA2C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6155A544-22DA-4A25-AB51-12131109BA2C}.Debug|x86.Build.0 = Debug|Any CPU
+		{6155A544-22DA-4A25-AB51-12131109BA2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6155A544-22DA-4A25-AB51-12131109BA2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6155A544-22DA-4A25-AB51-12131109BA2C}.Release|x64.ActiveCfg = Release|Any CPU
+		{6155A544-22DA-4A25-AB51-12131109BA2C}.Release|x64.Build.0 = Release|Any CPU
+		{6155A544-22DA-4A25-AB51-12131109BA2C}.Release|x86.ActiveCfg = Release|Any CPU
+		{6155A544-22DA-4A25-AB51-12131109BA2C}.Release|x86.Build.0 = Release|Any CPU
+		{9814E9E8-7CE3-41BD-8D34-10C3994DC953}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9814E9E8-7CE3-41BD-8D34-10C3994DC953}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9814E9E8-7CE3-41BD-8D34-10C3994DC953}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9814E9E8-7CE3-41BD-8D34-10C3994DC953}.Debug|x64.Build.0 = Debug|Any CPU
+		{9814E9E8-7CE3-41BD-8D34-10C3994DC953}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9814E9E8-7CE3-41BD-8D34-10C3994DC953}.Debug|x86.Build.0 = Debug|Any CPU
+		{9814E9E8-7CE3-41BD-8D34-10C3994DC953}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9814E9E8-7CE3-41BD-8D34-10C3994DC953}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9814E9E8-7CE3-41BD-8D34-10C3994DC953}.Release|x64.ActiveCfg = Release|Any CPU
+		{9814E9E8-7CE3-41BD-8D34-10C3994DC953}.Release|x64.Build.0 = Release|Any CPU
+		{9814E9E8-7CE3-41BD-8D34-10C3994DC953}.Release|x86.ActiveCfg = Release|Any CPU
+		{9814E9E8-7CE3-41BD-8D34-10C3994DC953}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{45A146D3-14B0-475C-AD61-CE2A4773655C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{0E739DFC-955A-4B2B-885D-1D62E59A08A3} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{9814E9E8-7CE3-41BD-8D34-10C3994DC953} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/apps/api/src/Langoose.Api/Controllers/ContentController.cs
+++ b/apps/api/src/Langoose.Api/Controllers/ContentController.cs
@@ -1,6 +1,7 @@
 using Langoose.Api.Models;
-using Langoose.Api.Services;
 using Langoose.Auth.Data.Models;
+using Langoose.Domain.Models;
+using Langoose.Domain.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -11,7 +12,7 @@ namespace Langoose.Api.Controllers;
 [Authorize]
 [Route("content")]
 public sealed class ContentController(
-    ContentService contentService,
+    IContentService contentService,
     UserManager<AuthUser> userManager) : ControllerBase
 {
     [HttpPost("enrich")]
@@ -25,7 +26,18 @@ public sealed class ContentController(
             return Unauthorized();
         }
 
-        return Ok(contentService.Enrich(request));
+        var input = new EnrichmentInput(request.EnglishText, request.RussianGlosses, request.ItemKind);
+        var result = contentService.Enrich(input);
+
+        return Ok(new EnrichmentResponse(
+            result.EnglishText,
+            result.RussianGlosses,
+            result.Difficulty,
+            result.PartOfSpeech,
+            [.. result.Examples.Select(e => new Models.ExampleCandidate(
+                e.SentenceText, e.ClozeText, e.TranslationHint, e.QualityScore, e.Origin))],
+            result.ValidationWarnings,
+            result.AcceptedVariants));
     }
 
     [HttpPost("report-issue")]
@@ -40,7 +52,8 @@ public sealed class ContentController(
             return Unauthorized();
         }
 
-        await contentService.ReportIssueAsync(user.Id, request, cancellationToken);
+        var input = new ReportIssueInput(request.ItemId, request.Reason, request.Details);
+        await contentService.ReportIssueAsync(user.Id, input, cancellationToken);
 
         return Accepted();
     }

--- a/apps/api/src/Langoose.Api/Controllers/DictionaryController.cs
+++ b/apps/api/src/Langoose.Api/Controllers/DictionaryController.cs
@@ -1,7 +1,7 @@
 using Langoose.Api.Models;
-using Langoose.Api.Services;
 using Langoose.Auth.Data.Models;
 using Langoose.Domain.Models;
+using Langoose.Domain.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -12,7 +12,7 @@ namespace Langoose.Api.Controllers;
 [Authorize]
 [Route("dictionary")]
 public sealed class DictionaryController(
-    DictionaryService dictionaryService,
+    IDictionaryService dictionaryService,
     UserManager<AuthUser> userManager) : ControllerBase
 {
     [HttpGet("items")]
@@ -40,7 +40,18 @@ public sealed class DictionaryController(
             return Unauthorized();
         }
 
-        return Ok(await dictionaryService.AddItemAsync(user.Id, request, cancellationToken));
+        var input = new AddItemInput(
+            request.EnglishText,
+            request.RussianGlosses,
+            request.ItemKind,
+            request.PartOfSpeech,
+            request.Difficulty,
+            request.Notes,
+            request.Tags,
+            request.CreatedByFlow,
+            request.GenerateExamples);
+
+        return Ok(await dictionaryService.AddItemAsync(user.Id, input, cancellationToken));
     }
 
     [HttpPatch("items/{itemId:guid}")]
@@ -56,7 +67,15 @@ public sealed class DictionaryController(
             return Unauthorized();
         }
 
-        var updated = await dictionaryService.PatchItemAsync(user.Id, itemId, request, cancellationToken);
+        var input = new PatchItemInput(
+            request.RussianGlosses,
+            request.PartOfSpeech,
+            request.Difficulty,
+            request.Notes,
+            request.Tags,
+            request.Status);
+
+        var updated = await dictionaryService.PatchItemAsync(user.Id, itemId, input, cancellationToken);
 
         return updated is null ? NotFound() : Ok(updated);
     }
@@ -75,7 +94,10 @@ public sealed class DictionaryController(
 
         try
         {
-            return Ok(await dictionaryService.ImportCsvAsync(user.Id, request, cancellationToken));
+            var result = await dictionaryService.ImportCsvAsync(
+                user.Id, request.CsvContent, request.FileName, cancellationToken);
+
+            return Ok(new ImportCsvResponse(result.TotalRows, result.ImportedRows, result.SkippedRows, result.Errors));
         }
         catch (ArgumentException exception)
         {

--- a/apps/api/src/Langoose.Api/Controllers/StudyController.cs
+++ b/apps/api/src/Langoose.Api/Controllers/StudyController.cs
@@ -1,6 +1,6 @@
 using Langoose.Api.Models;
-using Langoose.Api.Services;
 using Langoose.Auth.Data.Models;
+using Langoose.Domain.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -11,7 +11,7 @@ namespace Langoose.Api.Controllers;
 [Authorize]
 [Route("study")]
 public sealed class StudyController(
-    StudyService studyService,
+    IStudyService studyService,
     UserManager<AuthUser> userManager) : ControllerBase
 {
     [HttpGet("next")]
@@ -26,7 +26,19 @@ public sealed class StudyController(
 
         var card = await studyService.GetNextCardAsync(user.Id, cancellationToken);
 
-        return card is null ? NotFound() : Ok(card);
+        if (card is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(new StudyCardResponse(
+            card.ItemId,
+            card.Prompt,
+            card.TranslationHint,
+            card.Glosses,
+            card.ItemKind,
+            card.SourceType,
+            card.Difficulty));
     }
 
     [HttpPost("answer")]
@@ -41,9 +53,21 @@ public sealed class StudyController(
             return Unauthorized();
         }
 
-        var result = await studyService.SubmitAnswerAsync(user.Id, request, cancellationToken);
+        var result = await studyService.SubmitAnswerAsync(
+            user.Id, request.ItemId, request.SubmittedAnswer, cancellationToken);
 
-        return result is null ? NotFound() : Ok(result);
+        if (result is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(new StudyAnswerResult(
+            result.Verdict,
+            result.NormalizedAnswer,
+            result.AcceptedVariant,
+            result.ExpectedAnswer,
+            result.FeedbackCode,
+            result.NextDueAtUtc));
     }
 
     [HttpGet("dashboard")]
@@ -56,6 +80,14 @@ public sealed class StudyController(
             return Unauthorized();
         }
 
-        return Ok(await studyService.GetDashboardAsync(user.Id, cancellationToken));
+        var dashboard = await studyService.GetDashboardAsync(user.Id, cancellationToken);
+
+        return Ok(new ProgressDashboardResponse(
+            dashboard.TotalItems,
+            dashboard.DueNow,
+            dashboard.NewItems,
+            dashboard.BaseItems,
+            dashboard.CustomItems,
+            dashboard.StudiedToday));
     }
 }

--- a/apps/api/src/Langoose.Api/Dockerfile
+++ b/apps/api/src/Langoose.Api/Dockerfile
@@ -5,6 +5,7 @@ COPY ["apps/api/NuGet.Config", "apps/api/"]
 COPY ["apps/api/src/Langoose.Api/Langoose.Api.csproj", "apps/api/src/Langoose.Api/"]
 COPY ["apps/api/src/Langoose.Auth.Data/Langoose.Auth.Data.csproj", "apps/api/src/Langoose.Auth.Data/"]
 COPY ["apps/api/src/Langoose.Data/Langoose.Data.csproj", "apps/api/src/Langoose.Data/"]
+COPY ["apps/api/src/Langoose.Core/Langoose.Core.csproj", "apps/api/src/Langoose.Core/"]
 COPY ["apps/api/src/Langoose.Domain/Langoose.Domain.csproj", "apps/api/src/Langoose.Domain/"]
 RUN dotnet restore "apps/api/src/Langoose.Api/Langoose.Api.csproj" --configfile apps/api/NuGet.Config
 

--- a/apps/api/src/Langoose.Api/Langoose.Api.csproj
+++ b/apps/api/src/Langoose.Api/Langoose.Api.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\Langoose.Domain\Langoose.Domain.csproj" />
     <ProjectReference Include="..\Langoose.Data\Langoose.Data.csproj" />
     <ProjectReference Include="..\Langoose.Auth.Data\Langoose.Auth.Data.csproj" />
+    <ProjectReference Include="..\Langoose.Core\Langoose.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.4.0" />

--- a/apps/api/src/Langoose.Api/Middleware/AntiforgeryValidationMiddleware.cs
+++ b/apps/api/src/Langoose.Api/Middleware/AntiforgeryValidationMiddleware.cs
@@ -1,5 +1,5 @@
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Langoose.Api.Middleware;
 

--- a/apps/api/src/Langoose.Api/Program.cs
+++ b/apps/api/src/Langoose.Api/Program.cs
@@ -3,14 +3,15 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Langoose.Api.Configuration;
 using Langoose.Api.Middleware;
-using Langoose.Api.Services;
 using Langoose.Auth.Data;
 using Langoose.Auth.Data.Models;
+using Langoose.Core.Services;
 using Langoose.Data;
 using Langoose.Data.Seeding;
+using Langoose.Domain.Services;
 using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using IPNetwork = System.Net.IPNetwork;
 
@@ -115,10 +116,10 @@ builder.Services.AddOpenIddict()
         options.UseAspNetCore();
     });
 
-builder.Services.AddScoped<EnrichmentService>();
-builder.Services.AddScoped<DictionaryService>();
-builder.Services.AddScoped<StudyService>();
-builder.Services.AddScoped<ContentService>();
+builder.Services.AddScoped<IEnrichmentService, EnrichmentService>();
+builder.Services.AddScoped<IDictionaryService, DictionaryService>();
+builder.Services.AddScoped<IStudyService, StudyService>();
+builder.Services.AddScoped<IContentService, ContentService>();
 builder.Services.AddScoped<DatabaseSeeder>();
 
 builder.Services.AddControllers()

--- a/apps/api/src/Langoose.Auth.Data/Migrations/20260403103317_InitialAuthFoundation.cs
+++ b/apps/api/src/Langoose.Auth.Data/Migrations/20260403103317_InitialAuthFoundation.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 

--- a/apps/api/src/Langoose.Core/Langoose.Core.csproj
+++ b/apps/api/src/Langoose.Core/Langoose.Core.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Langoose.Domain\Langoose.Domain.csproj" />
+    <ProjectReference Include="..\Langoose.Data\Langoose.Data.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/apps/api/src/Langoose.Core/Services/ContentService.cs
+++ b/apps/api/src/Langoose.Core/Services/ContentService.cs
@@ -1,31 +1,31 @@
-using Langoose.Api.Models;
 using Langoose.Data;
 using Langoose.Domain.Enums;
 using Langoose.Domain.Models;
+using Langoose.Domain.Services;
 using Microsoft.EntityFrameworkCore;
 
-namespace Langoose.Api.Services;
+namespace Langoose.Core.Services;
 
 public sealed class ContentService(
     AppDbContext dbContext,
-    EnrichmentService enrichmentService)
+    IEnrichmentService enrichmentService) : IContentService
 {
-    public EnrichmentResponse Enrich(EnrichmentRequest request) => enrichmentService.Enrich(request);
+    public EnrichmentResult Enrich(EnrichmentInput input) => enrichmentService.Enrich(input);
 
-    public async Task ReportIssueAsync(Guid userId, ReportIssueRequest request, CancellationToken cancellationToken)
+    public async Task ReportIssueAsync(Guid userId, ReportIssueInput input, CancellationToken cancellationToken)
     {
         dbContext.ContentFlags.Add(new ContentFlag
         {
             Id = Guid.NewGuid(),
             UserId = userId,
-            ItemId = request.ItemId,
-            Reason = request.Reason.Trim(),
-            Details = string.IsNullOrWhiteSpace(request.Details) ? null : request.Details.Trim(),
+            ItemId = input.ItemId,
+            Reason = input.Reason.Trim(),
+            Details = string.IsNullOrWhiteSpace(input.Details) ? null : input.Details.Trim(),
             CreatedAtUtc = DateTimeOffset.UtcNow
         });
 
         var item = await dbContext.DictionaryItems.FirstOrDefaultAsync(
-            x => x.Id == request.ItemId,
+            x => x.Id == input.ItemId,
             cancellationToken);
 
         if (item is not null)

--- a/apps/api/src/Langoose.Core/Services/DictionaryService.cs
+++ b/apps/api/src/Langoose.Core/Services/DictionaryService.cs
@@ -1,16 +1,17 @@
 using System.Text;
-using Langoose.Api.Models;
+using Langoose.Core.Utilities;
 using Langoose.Data;
 using Langoose.Domain.Constants;
 using Langoose.Domain.Enums;
 using Langoose.Domain.Models;
+using Langoose.Domain.Services;
 using Microsoft.EntityFrameworkCore;
 
-namespace Langoose.Api.Services;
+namespace Langoose.Core.Services;
 
 public sealed class DictionaryService(
     AppDbContext dbContext,
-    EnrichmentService enrichmentService)
+    IEnrichmentService enrichmentService) : IDictionaryService
 {
     private static readonly string[] RequiredCsvHeaders = ["english term", "russian translation s", "type"];
     private static readonly string[] OptionalCsvHeaders = ["notes", "tags"];
@@ -26,19 +27,18 @@ public sealed class DictionaryService(
             await dbContext.SaveChangesAsync(cancellationToken);
         }
 
-        return GetVisibleItems(state.DictionaryItems, userId)
+        return [.. GetVisibleItems(state.DictionaryItems, userId)
             .OrderBy(item => item.SourceType)
-            .ThenBy(item => item.EnglishText)
-            .ToList();
+            .ThenBy(item => item.EnglishText)];
     }
 
     public async Task<DictionaryItem> AddItemAsync(
         Guid userId,
-        DictionaryItemRequest request,
+        AddItemInput input,
         CancellationToken cancellationToken)
     {
         var state = await LoadTrackedStateAsync(dbContext, cancellationToken);
-        var (item, _) = await UpsertItemAsync(dbContext, state, userId, request, cancellationToken);
+        var (item, _) = await UpsertItemAsync(dbContext, state, userId, input, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
 
         return item;
@@ -47,7 +47,7 @@ public sealed class DictionaryService(
     public async Task<DictionaryItem?> PatchItemAsync(
         Guid userId,
         Guid itemId,
-        DictionaryItemPatchRequest request,
+        PatchItemInput input,
         CancellationToken cancellationToken)
     {
         var item = await dbContext.DictionaryItems.FirstOrDefaultAsync(candidate =>
@@ -59,33 +59,33 @@ public sealed class DictionaryService(
             return null;
         }
 
-        if (request.RussianGlosses is not null)
+        if (input.RussianGlosses is not null)
         {
-            item.RussianGlosses = CleanValues(request.RussianGlosses);
+            item.RussianGlosses = CleanValues(input.RussianGlosses);
         }
 
-        if (!string.IsNullOrWhiteSpace(request.PartOfSpeech))
+        if (!string.IsNullOrWhiteSpace(input.PartOfSpeech))
         {
-            item.PartOfSpeech = TextNormalizer.CleanInput(request.PartOfSpeech);
+            item.PartOfSpeech = TextNormalizer.CleanInput(input.PartOfSpeech);
         }
 
-        if (!string.IsNullOrWhiteSpace(request.Difficulty))
+        if (!string.IsNullOrWhiteSpace(input.Difficulty))
         {
-            item.Difficulty = TextNormalizer.CleanInput(request.Difficulty);
+            item.Difficulty = TextNormalizer.CleanInput(input.Difficulty);
         }
 
-        if (request.Notes is not null)
+        if (input.Notes is not null)
         {
-            item.Notes = TextNormalizer.CleanInput(request.Notes);
+            item.Notes = TextNormalizer.CleanInput(input.Notes);
         }
 
-        if (request.Tags is not null)
+        if (input.Tags is not null)
         {
-            item.Tags = CleanValues(request.Tags);
+            item.Tags = CleanValues(input.Tags);
         }
 
-        if (!string.IsNullOrWhiteSpace(request.Status) &&
-            Enum.TryParse<DictionaryItemStatus>(request.Status, true, out var status))
+        if (!string.IsNullOrWhiteSpace(input.Status) &&
+            Enum.TryParse<DictionaryItemStatus>(input.Status, true, out var status))
         {
             item.Status = status;
         }
@@ -95,12 +95,13 @@ public sealed class DictionaryService(
         return item;
     }
 
-    public async Task<ImportCsvResponse> ImportCsvAsync(
+    public async Task<ImportResult> ImportCsvAsync(
         Guid userId,
-        ImportCsvRequest request,
+        string csvContent,
+        string fileName,
         CancellationToken cancellationToken)
     {
-        var rows = request.CsvContent.Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries);
+        var rows = csvContent.Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries);
 
         if (rows.Length == 0)
         {
@@ -109,8 +110,8 @@ public sealed class DictionaryService(
 
         ValidateCsvHeader(rows[0]);
 
-        var errors = new List<string>();
-        var candidates = new List<DictionaryItemRequest>();
+        List<string> errors = [];
+        List<AddItemInput> candidates = [];
 
         foreach (var row in rows.Skip(1))
         {
@@ -136,7 +137,7 @@ public sealed class DictionaryService(
                 continue;
             }
 
-            candidates.Add(new DictionaryItemRequest(
+            candidates.Add(new AddItemInput(
                 english,
                 russianGlosses,
                 type,
@@ -149,7 +150,7 @@ public sealed class DictionaryService(
 
         if (errors.Count > 0)
         {
-            return new ImportCsvResponse(
+            return new ImportResult(
                 Math.Max(0, rows.Length - 1),
                 0,
                 Math.Max(0, rows.Length - 1),
@@ -178,7 +179,7 @@ public sealed class DictionaryService(
         {
             Id = Guid.NewGuid(),
             UserId = userId,
-            FileName = request.FileName,
+            FileName = fileName,
             TotalRows = Math.Max(0, rows.Length - 1),
             ImportedRows = imported,
             SkippedRows = skipped,
@@ -189,7 +190,7 @@ public sealed class DictionaryService(
 
         await dbContext.SaveChangesAsync(cancellationToken);
 
-        return new ImportCsvResponse(Math.Max(0, rows.Length - 1), imported, skipped, []);
+        return new ImportResult(Math.Max(0, rows.Length - 1), imported, skipped, []);
     }
 
     public async Task<string> ExportCsvAsync(Guid userId, CancellationToken cancellationToken)
@@ -201,7 +202,7 @@ public sealed class DictionaryService(
             await dbContext.SaveChangesAsync(cancellationToken);
         }
 
-        var rows = new List<string> { "English term,Russian translation(s),Type,Notes,Tags" };
+        List<string> rows = ["English term,Russian translation(s),Type,Notes,Tags"];
         var visibleCustomItems = GetVisibleItems(state.DictionaryItems, userId)
             .Where(candidate => candidate.OwnerId == userId)
             .OrderBy(candidate => candidate.EnglishText);
@@ -256,14 +257,14 @@ public sealed class DictionaryService(
         AppDbContext dbContext,
         AppState state,
         Guid userId,
-        DictionaryItemRequest request,
+        AddItemInput input,
         CancellationToken cancellationToken)
     {
         NormalizeCustomDuplicates(dbContext, state, userId);
 
-        var cleanedEnglish = TextNormalizer.CleanInput(request.EnglishText);
+        var cleanedEnglish = TextNormalizer.CleanInput(input.EnglishText);
         var normalizedEnglish = TextNormalizer.NormalizeForComparison(cleanedEnglish);
-        var itemKind = ResolveItemKind(request.ItemKind, cleanedEnglish);
+        var itemKind = ResolveItemKind(input.ItemKind, cleanedEnglish);
         var existingCustom = state.DictionaryItems.FirstOrDefault(item =>
             item.OwnerId == userId &&
             TextNormalizer.NormalizeForComparison(item.EnglishText) == normalizedEnglish);
@@ -272,13 +273,13 @@ public sealed class DictionaryService(
             TextNormalizer.NormalizeForComparison(item.EnglishText) == normalizedEnglish);
 
         var enrichment = enrichmentService.Enrich(
-            new EnrichmentRequest(cleanedEnglish, request.RussianGlosses, request.ItemKind));
-        var glosses = (request.RussianGlosses?.Count ?? 0) > 0
-            ? request.RussianGlosses!
+            new EnrichmentInput(cleanedEnglish, input.RussianGlosses, input.ItemKind));
+        var glosses = (input.RussianGlosses?.Count ?? 0) > 0
+            ? input.RussianGlosses!
             : enrichment.RussianGlosses;
         var cleanedGlosses = CleanValues(glosses);
-        var cleanedTags = CleanValues(request.Tags ?? []);
-        var cleanedNotes = TextNormalizer.CleanInput(request.Notes ?? "");
+        var cleanedTags = CleanValues(input.Tags ?? []);
+        var cleanedNotes = TextNormalizer.CleanInput(input.Notes ?? "");
 
         if (existingCustom is not null)
         {
@@ -324,21 +325,20 @@ public sealed class DictionaryService(
             OwnerId = userId,
             SourceType = SourceType.Custom,
             EnglishText = cleanedEnglish,
-            RussianGlosses = cleanedGlosses.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            RussianGlosses = [.. cleanedGlosses.Distinct(StringComparer.OrdinalIgnoreCase)],
             ItemKind = itemKind,
-            PartOfSpeech = request.PartOfSpeech?.Trim() ?? enrichment.PartOfSpeech,
-            Difficulty = request.Difficulty?.Trim() ?? enrichment.Difficulty,
+            PartOfSpeech = input.PartOfSpeech?.Trim() ?? enrichment.PartOfSpeech,
+            Difficulty = input.Difficulty?.Trim() ?? enrichment.Difficulty,
             Status = DictionaryItemStatus.Active,
             Notes = cleanedNotes,
             Tags = cleanedTags,
-            CreatedByFlow = request.CreatedByFlow?.Trim() ?? "quick-add",
-            AcceptedVariants = enrichment.AcceptedVariants
+            CreatedByFlow = input.CreatedByFlow?.Trim() ?? "quick-add",
+            AcceptedVariants = [.. enrichment.AcceptedVariants
                 .Append(cleanedEnglish)
                 .Append(normalizedEnglish)
                 .Where(value => !string.IsNullOrWhiteSpace(value))
                 .Select(TextNormalizer.CleanInput)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList(),
+                .Distinct(StringComparer.OrdinalIgnoreCase)],
             CreatedAtUtc = DateTimeOffset.UtcNow
         };
 
@@ -349,7 +349,7 @@ public sealed class DictionaryService(
         dbContext.DictionaryItems.Add(item);
         state.DictionaryItems.Add(item);
 
-        if (request.GenerateExamples)
+        if (input.GenerateExamples)
         {
             var validExamples = enrichment.Examples.Where(candidate =>
                 !enrichment.ValidationWarnings.Contains(
@@ -389,14 +389,13 @@ public sealed class DictionaryService(
 
     private static IReadOnlyList<DictionaryItem> GetVisibleItems(List<DictionaryItem> dictionaryItems, Guid userId)
     {
-        return dictionaryItems
+        return [.. dictionaryItems
             .Where(item => item.OwnerId is null || item.OwnerId == userId)
             .GroupBy(item => TextNormalizer.NormalizeForComparison(item.EnglishText))
             .Select(group => group
                 .OrderByDescending(item => item.OwnerId == userId)
                 .ThenBy(item => item.CreatedAtUtc)
-                .First())
-            .ToList();
+                .First())];
     }
 
     private static async Task<AppState> LoadTrackedStateAsync(
@@ -416,9 +415,8 @@ public sealed class DictionaryService(
 
     private static void ValidateCsvHeader(string headerRow)
     {
-        var headers = ParseCsvRow(headerRow)
-            .Select(header => TextNormalizer.NormalizeForComparison(header))
-            .ToList();
+        List<string> headers = [.. ParseCsvRow(headerRow)
+            .Select(header => TextNormalizer.NormalizeForComparison(header))];
 
         if (headers.Count < 3 || headers.Count > 5)
         {
@@ -456,26 +454,23 @@ public sealed class DictionaryService(
         List<string> acceptedVariants,
         string normalizedEnglish)
     {
-        existing.RussianGlosses = existing.RussianGlosses
+        existing.RussianGlosses = [.. existing.RussianGlosses
             .Concat(cleanedGlosses)
             .Where(value => !string.IsNullOrWhiteSpace(value))
             .Select(TextNormalizer.CleanInput)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-        existing.Tags = existing.Tags
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+        existing.Tags = [.. existing.Tags
             .Concat(cleanedTags)
             .Where(value => !string.IsNullOrWhiteSpace(value))
             .Select(TextNormalizer.CleanInput)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-        existing.AcceptedVariants = existing.AcceptedVariants
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+        existing.AcceptedVariants = [.. existing.AcceptedVariants
             .Concat(acceptedVariants)
             .Append(cleanedEnglish)
             .Append(normalizedEnglish)
             .Where(value => !string.IsNullOrWhiteSpace(value))
             .Select(TextNormalizer.CleanInput)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
         existing.ItemKind = existing.ItemKind == ItemKind.Phrase || itemKind == ItemKind.Phrase
             ? ItemKind.Phrase
             : ItemKind.Word;
@@ -543,29 +538,25 @@ public sealed class DictionaryService(
         DictionaryItem duplicate,
         Guid userId)
     {
-        primary.RussianGlosses = primary.RussianGlosses
+        primary.RussianGlosses = [.. primary.RussianGlosses
             .Concat(duplicate.RussianGlosses)
             .Where(value => !string.IsNullOrWhiteSpace(value))
             .Select(TextNormalizer.CleanInput)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-        primary.Tags = primary.Tags
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+        primary.Tags = [.. primary.Tags
             .Concat(duplicate.Tags)
             .Where(value => !string.IsNullOrWhiteSpace(value))
             .Select(TextNormalizer.CleanInput)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-        primary.AcceptedVariants = primary.AcceptedVariants
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+        primary.AcceptedVariants = [.. primary.AcceptedVariants
             .Concat(duplicate.AcceptedVariants)
             .Where(value => !string.IsNullOrWhiteSpace(value))
             .Select(TextNormalizer.CleanInput)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-        primary.Distractors = primary.Distractors
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+        primary.Distractors = [.. primary.Distractors
             .Concat(duplicate.Distractors)
             .Where(value => !string.IsNullOrWhiteSpace(value))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
         primary.ItemKind = primary.ItemKind == ItemKind.Phrase || duplicate.ItemKind == ItemKind.Phrase
             ? ItemKind.Phrase
             : ItemKind.Word;
@@ -631,7 +622,7 @@ public sealed class DictionaryService(
 
     private static List<string> ParseCsvRow(string row)
     {
-        var result = new List<string>();
+        List<string> result = [];
         var current = new StringBuilder();
         var inQuotes = false;
 
@@ -670,21 +661,19 @@ public sealed class DictionaryService(
 
     private static List<string> CleanValues(IEnumerable<string> values)
     {
-        return values
+        return [.. values
             .Where(value => !string.IsNullOrWhiteSpace(value))
             .Select(TextNormalizer.CleanInput)
             .Where(value => !string.IsNullOrWhiteSpace(value))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
     }
 
     private static List<string> SplitPipeValues(string value)
     {
-        return value
+        return [.. value
             .Split('|', StringSplitOptions.RemoveEmptyEntries)
             .Select(TextNormalizer.CleanInput)
-            .Where(candidate => !string.IsNullOrWhiteSpace(candidate))
-            .ToList();
+            .Where(candidate => !string.IsNullOrWhiteSpace(candidate))];
     }
 
     private sealed class AppState

--- a/apps/api/src/Langoose.Core/Services/EnrichmentService.cs
+++ b/apps/api/src/Langoose.Core/Services/EnrichmentService.cs
@@ -1,9 +1,11 @@
-using Langoose.Api.Models;
+using Langoose.Core.Utilities;
 using Langoose.Domain.Constants;
+using Langoose.Domain.Models;
+using Langoose.Domain.Services;
 
-namespace Langoose.Api.Services;
+namespace Langoose.Core.Services;
 
-public sealed class EnrichmentService
+public sealed class EnrichmentService : IEnrichmentService
 {
     private static readonly Dictionary<string, LexiconEntry> Lexicon =
         new(StringComparer.OrdinalIgnoreCase)
@@ -40,11 +42,11 @@ public sealed class EnrichmentService
                 ["get better"])
         };
 
-    public EnrichmentResponse Enrich(EnrichmentRequest request)
+    public EnrichmentResult Enrich(EnrichmentInput input)
     {
-        var englishText = request.EnglishText.Trim();
-        var warnings = new List<string>();
-        var inputGlosses = request.RussianGlosses?
+        var englishText = input.EnglishText.Trim();
+        List<string> warnings = [];
+        var inputGlosses = input.RussianGlosses?
             .Where(x => !string.IsNullOrWhiteSpace(x))
             .Select(x => x.Trim())
             .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -59,7 +61,7 @@ public sealed class EnrichmentService
         if (Lexicon.TryGetValue(englishText, out var entry))
         {
             glosses = inputGlosses.Count > 0 ? inputGlosses : entry.Glosses;
-            partOfSpeech = InferPartOfSpeech(request.ItemKind, entry.PartOfSpeech);
+            partOfSpeech = InferPartOfSpeech(input.ItemKind, entry.PartOfSpeech);
             difficulty = entry.Difficulty;
             examples = entry.Examples;
             acceptedVariants = [englishText, .. entry.Variants];
@@ -68,7 +70,7 @@ public sealed class EnrichmentService
         {
             glosses = inputGlosses;
             partOfSpeech = InferPartOfSpeech(
-                request.ItemKind,
+                input.ItemKind,
                 englishText.Contains(' ') ? "phrase" : "word");
             difficulty = englishText.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length > 1
                 ? "B1"
@@ -83,26 +85,25 @@ public sealed class EnrichmentService
             }
         }
 
-        var candidates = examples
+        List<ExampleCandidate> candidates = [.. examples
             .Select(sentence => new ExampleCandidate(
                 sentence,
                 sentence.Replace(englishText, "____", StringComparison.OrdinalIgnoreCase),
                 BuildTranslationHint(glosses),
                 ExampleQualityScores.EnrichmentFallback,
-                "ai-fallback"))
-            .ToList();
+                "ai-fallback"))];
 
         var validationWarnings = Validate(englishText, glosses, candidates);
         warnings.AddRange(validationWarnings);
 
-        return new EnrichmentResponse(
+        return new EnrichmentResult(
             englishText,
             glosses,
             difficulty,
             partOfSpeech,
             candidates,
-            warnings.Distinct().ToList(),
-            acceptedVariants.Distinct(StringComparer.OrdinalIgnoreCase).ToList());
+            [.. warnings.Distinct()],
+            [.. acceptedVariants.Distinct(StringComparer.OrdinalIgnoreCase)]);
     }
 
     public static IReadOnlyList<string> Validate(
@@ -110,7 +111,7 @@ public sealed class EnrichmentService
         List<string> glosses,
         List<ExampleCandidate> examples)
     {
-        var warnings = new List<string>();
+        List<string> warnings = [];
 
         if (string.IsNullOrWhiteSpace(englishText))
         {

--- a/apps/api/src/Langoose.Core/Services/StudyService.cs
+++ b/apps/api/src/Langoose.Core/Services/StudyService.cs
@@ -1,13 +1,14 @@
-using Langoose.Api.Models;
+using Langoose.Core.Utilities;
 using Langoose.Data;
 using Langoose.Domain.Constants;
 using Langoose.Domain.Enums;
 using Langoose.Domain.Models;
+using Langoose.Domain.Services;
 using Microsoft.EntityFrameworkCore;
 
-namespace Langoose.Api.Services;
+namespace Langoose.Core.Services;
 
-public sealed class StudyService(AppDbContext dbContext)
+public sealed class StudyService(AppDbContext dbContext) : IStudyService
 {
     private const double PhraseSimilarityThreshold = 0.60;
     private const double CorrectStabilityCap = 0.95;
@@ -20,7 +21,7 @@ public sealed class StudyService(AppDbContext dbContext)
     private const double IncorrectStabilityPenalty = 0.12;
     private const int IncorrectDueDelayMinutes = 10;
 
-    public async Task<StudyCardResponse?> GetNextCardAsync(
+    public async Task<StudyCard?> GetNextCardAsync(
         Guid userId,
         CancellationToken cancellationToken)
     {
@@ -30,9 +31,8 @@ public sealed class StudyService(AppDbContext dbContext)
             .ToListAsync(cancellationToken);
         var exampleSentences = await dbContext.ExampleSentences.ToListAsync(cancellationToken);
 
-        var visibleItems = GetVisibleItems(dictionaryItems, userId)
-            .Where(x => x.Status == DictionaryItemStatus.Active)
-            .ToList();
+        List<DictionaryItem> visibleItems = [.. GetVisibleItems(dictionaryItems, userId)
+            .Where(x => x.Status == DictionaryItemStatus.Active)];
         var reviewStatesByItemId = reviewStates.ToDictionary(x => x.ItemId);
 
         foreach (var item in visibleItems.Where(x => !reviewStatesByItemId.ContainsKey(x.Id)))
@@ -50,11 +50,10 @@ public sealed class StudyService(AppDbContext dbContext)
             dbContext.ReviewStates.Add(reviewState);
         }
 
-        var dueStates = reviewStatesByItemId.Values
+        List<ReviewState> dueStates = [.. reviewStatesByItemId.Values
             .Where(x => visibleItems.Any(item => item.Id == x.ItemId))
             .OrderBy(x => x.DueAtUtc)
-            .ThenBy(x => x.SuccessCount)
-            .ToList();
+            .ThenBy(x => x.SuccessCount)];
 
         if (dueStates.Count == 0)
         {
@@ -79,7 +78,7 @@ public sealed class StudyService(AppDbContext dbContext)
 
         await dbContext.SaveChangesAsync(cancellationToken);
 
-        return new StudyCardResponse(
+        return new StudyCard(
             itemForStudy.Id,
             sentence.ClozeText,
             sentence.TranslationHint,
@@ -89,13 +88,14 @@ public sealed class StudyService(AppDbContext dbContext)
             itemForStudy.Difficulty);
     }
 
-    public async Task<StudyAnswerResult?> SubmitAnswerAsync(
+    public async Task<AnswerResult?> SubmitAnswerAsync(
         Guid userId,
-        StudyAnswerRequest request,
+        Guid itemId,
+        string submittedAnswer,
         CancellationToken cancellationToken)
     {
         var item = await dbContext.DictionaryItems.FirstOrDefaultAsync(x =>
-            x.Id == request.ItemId &&
+            x.Id == itemId &&
             (x.OwnerId == null || x.OwnerId == userId),
             cancellationToken);
 
@@ -125,7 +125,7 @@ public sealed class StudyService(AppDbContext dbContext)
             dbContext.ReviewStates.Add(reviewState);
         }
 
-        var evaluation = EvaluateAnswer(item, request.SubmittedAnswer);
+        var evaluation = EvaluateAnswer(item, submittedAnswer);
         ApplyScheduler(reviewState, evaluation.Verdict);
 
         dbContext.StudyEvents.Add(new StudyEvent
@@ -134,7 +134,7 @@ public sealed class StudyService(AppDbContext dbContext)
             UserId = userId,
             ItemId = item.Id,
             AnsweredAtUtc = DateTimeOffset.UtcNow,
-            SubmittedAnswer = request.SubmittedAnswer,
+            SubmittedAnswer = submittedAnswer,
             NormalizedAnswer = evaluation.NormalizedAnswer,
             Verdict = evaluation.Verdict,
             FeedbackCode = evaluation.FeedbackCode
@@ -145,22 +145,21 @@ public sealed class StudyService(AppDbContext dbContext)
         return evaluation with { NextDueAtUtc = reviewState.DueAtUtc };
     }
 
-    public StudyAnswerResult EvaluateAnswer(DictionaryItem item, string submittedAnswer)
+    public AnswerResult EvaluateAnswer(DictionaryItem item, string submittedAnswer)
     {
         var normalizedSubmitted = TextNormalizer.NormalizeForComparison(submittedAnswer);
         var expected = item.EnglishText;
         var normalizedExpected = TextNormalizer.NormalizeForComparison(expected);
-        var acceptedVariants = item.AcceptedVariants
+        List<string> acceptedVariants = [.. item.AcceptedVariants
             .Append(expected)
             .Select(TextNormalizer.NormalizeForComparison)
-            .Distinct()
-            .ToList();
+            .Distinct()];
 
         if (acceptedVariants.Contains(normalizedSubmitted))
         {
             var isVariant = normalizedSubmitted != normalizedExpected;
 
-            return new StudyAnswerResult(
+            return new AnswerResult(
                 isVariant ? StudyVerdict.AlmostCorrect : StudyVerdict.Correct,
                 normalizedSubmitted,
                 normalizedSubmitted,
@@ -206,7 +205,7 @@ public sealed class StudyService(AppDbContext dbContext)
                 FeedbackCode.AcceptedVariant);
         }
 
-        return new StudyAnswerResult(
+        return new AnswerResult(
             StudyVerdict.Incorrect,
             normalizedSubmitted,
             null,
@@ -215,7 +214,7 @@ public sealed class StudyService(AppDbContext dbContext)
             DateTimeOffset.UtcNow);
     }
 
-    public async Task<ProgressDashboardResponse> GetDashboardAsync(
+    public async Task<ProgressDashboard> GetDashboardAsync(
         Guid userId,
         CancellationToken cancellationToken)
     {
@@ -233,7 +232,7 @@ public sealed class StudyService(AppDbContext dbContext)
             x.AnsweredAtUtc < endOfTodayUtc &&
             visibleItemIds.Contains(x.ItemId), cancellationToken);
 
-        return new ProgressDashboardResponse(
+        return new ProgressDashboard(
             items.Count,
             states.Count(x => x.DueAtUtc <= DateTimeOffset.UtcNow),
             states.Count(x => x.SuccessCount == 0),
@@ -244,14 +243,13 @@ public sealed class StudyService(AppDbContext dbContext)
 
     private static List<DictionaryItem> GetVisibleItems(List<DictionaryItem> dictionaryItems, Guid userId)
     {
-        return dictionaryItems
+        return [.. dictionaryItems
             .Where(x => x.OwnerId is null || x.OwnerId == userId)
             .GroupBy(x => TextNormalizer.NormalizeForComparison(x.EnglishText))
             .Select(group => group
                 .OrderByDescending(x => x.OwnerId == userId)
                 .ThenBy(x => x.CreatedAtUtc)
-                .First())
-            .ToList();
+                .First())];
     }
 
     private static double PhraseSimilarity(string left, string right)
@@ -316,13 +314,13 @@ public sealed class StudyService(AppDbContext dbContext)
         }
     }
 
-    private static StudyAnswerResult CreateAlmostCorrectResult(
+    private static AnswerResult CreateAlmostCorrectResult(
         string normalizedSubmitted,
         string normalizedExpected,
         string expected,
         FeedbackCode feedbackCode)
     {
-        return new StudyAnswerResult(
+        return new AnswerResult(
             StudyVerdict.AlmostCorrect,
             normalizedSubmitted,
             normalizedExpected,

--- a/apps/api/src/Langoose.Core/Utilities/TextNormalizer.cs
+++ b/apps/api/src/Langoose.Core/Utilities/TextNormalizer.cs
@@ -1,11 +1,13 @@
 using System.Text;
 using System.Text.RegularExpressions;
 
-namespace Langoose.Api.Services;
+namespace Langoose.Core.Utilities;
 
-public static class TextNormalizer
+public static partial class TextNormalizer
 {
-    private static readonly Regex WhitespaceRegex = new(@"\s+", RegexOptions.Compiled);
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
+
     private static readonly HashSet<string> ArticleWords = ["a", "an", "the"];
 
     public static string NormalizeForComparison(string value)
@@ -30,7 +32,7 @@ public static class TextNormalizer
             }
         }
 
-        return WhitespaceRegex.Replace(builder.ToString(), " ").Trim();
+        return WhitespaceRegex().Replace(builder.ToString(), " ").Trim();
     }
 
     public static string CleanInput(string value)

--- a/apps/api/src/Langoose.Data/Migrations/20260403104256_InitialAppFoundation.cs
+++ b/apps/api/src/Langoose.Data/Migrations/20260403104256_InitialAppFoundation.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Migrations;
 

--- a/apps/api/src/Langoose.Domain/Models/AddItemInput.cs
+++ b/apps/api/src/Langoose.Domain/Models/AddItemInput.cs
@@ -1,0 +1,12 @@
+namespace Langoose.Domain.Models;
+
+public sealed record AddItemInput(
+    string EnglishText,
+    List<string>? RussianGlosses,
+    string? ItemKind,
+    string? PartOfSpeech,
+    string? Difficulty,
+    string? Notes,
+    List<string>? Tags,
+    string? CreatedByFlow,
+    bool GenerateExamples = true);

--- a/apps/api/src/Langoose.Domain/Models/AnswerResult.cs
+++ b/apps/api/src/Langoose.Domain/Models/AnswerResult.cs
@@ -1,0 +1,11 @@
+using Langoose.Domain.Enums;
+
+namespace Langoose.Domain.Models;
+
+public sealed record AnswerResult(
+    StudyVerdict Verdict,
+    string NormalizedAnswer,
+    string? AcceptedVariant,
+    string ExpectedAnswer,
+    FeedbackCode FeedbackCode,
+    DateTimeOffset NextDueAtUtc);

--- a/apps/api/src/Langoose.Domain/Models/EnrichmentInput.cs
+++ b/apps/api/src/Langoose.Domain/Models/EnrichmentInput.cs
@@ -1,0 +1,3 @@
+namespace Langoose.Domain.Models;
+
+public sealed record EnrichmentInput(string EnglishText, List<string>? RussianGlosses, string? ItemKind);

--- a/apps/api/src/Langoose.Domain/Models/EnrichmentResult.cs
+++ b/apps/api/src/Langoose.Domain/Models/EnrichmentResult.cs
@@ -1,0 +1,10 @@
+namespace Langoose.Domain.Models;
+
+public sealed record EnrichmentResult(
+    string EnglishText,
+    List<string> RussianGlosses,
+    string Difficulty,
+    string PartOfSpeech,
+    List<ExampleCandidate> Examples,
+    List<string> ValidationWarnings,
+    List<string> AcceptedVariants);

--- a/apps/api/src/Langoose.Domain/Models/ExampleCandidate.cs
+++ b/apps/api/src/Langoose.Domain/Models/ExampleCandidate.cs
@@ -1,0 +1,8 @@
+namespace Langoose.Domain.Models;
+
+public sealed record ExampleCandidate(
+    string SentenceText,
+    string ClozeText,
+    string TranslationHint,
+    double QualityScore,
+    string Origin);

--- a/apps/api/src/Langoose.Domain/Models/ImportResult.cs
+++ b/apps/api/src/Langoose.Domain/Models/ImportResult.cs
@@ -1,0 +1,3 @@
+namespace Langoose.Domain.Models;
+
+public sealed record ImportResult(int TotalRows, int ImportedRows, int SkippedRows, List<string> Errors);

--- a/apps/api/src/Langoose.Domain/Models/PatchItemInput.cs
+++ b/apps/api/src/Langoose.Domain/Models/PatchItemInput.cs
@@ -1,0 +1,9 @@
+namespace Langoose.Domain.Models;
+
+public sealed record PatchItemInput(
+    List<string>? RussianGlosses,
+    string? PartOfSpeech,
+    string? Difficulty,
+    string? Notes,
+    List<string>? Tags,
+    string? Status);

--- a/apps/api/src/Langoose.Domain/Models/ProgressDashboard.cs
+++ b/apps/api/src/Langoose.Domain/Models/ProgressDashboard.cs
@@ -1,0 +1,9 @@
+namespace Langoose.Domain.Models;
+
+public sealed record ProgressDashboard(
+    int TotalItems,
+    int DueNow,
+    int NewItems,
+    int BaseItems,
+    int CustomItems,
+    int StudiedToday);

--- a/apps/api/src/Langoose.Domain/Models/ReportIssueInput.cs
+++ b/apps/api/src/Langoose.Domain/Models/ReportIssueInput.cs
@@ -1,0 +1,3 @@
+namespace Langoose.Domain.Models;
+
+public sealed record ReportIssueInput(Guid ItemId, string Reason, string? Details);

--- a/apps/api/src/Langoose.Domain/Models/StudyCard.cs
+++ b/apps/api/src/Langoose.Domain/Models/StudyCard.cs
@@ -1,0 +1,10 @@
+namespace Langoose.Domain.Models;
+
+public sealed record StudyCard(
+    Guid ItemId,
+    string Prompt,
+    string TranslationHint,
+    List<string> Glosses,
+    string ItemKind,
+    string SourceType,
+    string Difficulty);

--- a/apps/api/src/Langoose.Domain/Services/IContentService.cs
+++ b/apps/api/src/Langoose.Domain/Services/IContentService.cs
@@ -1,0 +1,10 @@
+using Langoose.Domain.Models;
+
+namespace Langoose.Domain.Services;
+
+public interface IContentService
+{
+    EnrichmentResult Enrich(EnrichmentInput input);
+
+    Task ReportIssueAsync(Guid userId, ReportIssueInput input, CancellationToken cancellationToken);
+}

--- a/apps/api/src/Langoose.Domain/Services/IDictionaryService.cs
+++ b/apps/api/src/Langoose.Domain/Services/IDictionaryService.cs
@@ -1,0 +1,18 @@
+using Langoose.Domain.Models;
+
+namespace Langoose.Domain.Services;
+
+public interface IDictionaryService
+{
+    Task<IReadOnlyList<DictionaryItem>> GetItemsAsync(Guid userId, CancellationToken cancellationToken);
+
+    Task<DictionaryItem> AddItemAsync(Guid userId, AddItemInput input, CancellationToken cancellationToken);
+
+    Task<DictionaryItem?> PatchItemAsync(Guid userId, Guid itemId, PatchItemInput input, CancellationToken cancellationToken);
+
+    Task<ImportResult> ImportCsvAsync(Guid userId, string csvContent, string fileName, CancellationToken cancellationToken);
+
+    Task<string> ExportCsvAsync(Guid userId, CancellationToken cancellationToken);
+
+    Task ClearCustomDataAsync(Guid userId, CancellationToken cancellationToken);
+}

--- a/apps/api/src/Langoose.Domain/Services/IEnrichmentService.cs
+++ b/apps/api/src/Langoose.Domain/Services/IEnrichmentService.cs
@@ -1,0 +1,8 @@
+using Langoose.Domain.Models;
+
+namespace Langoose.Domain.Services;
+
+public interface IEnrichmentService
+{
+    EnrichmentResult Enrich(EnrichmentInput input);
+}

--- a/apps/api/src/Langoose.Domain/Services/IStudyService.cs
+++ b/apps/api/src/Langoose.Domain/Services/IStudyService.cs
@@ -1,0 +1,14 @@
+using Langoose.Domain.Models;
+
+namespace Langoose.Domain.Services;
+
+public interface IStudyService
+{
+    Task<StudyCard?> GetNextCardAsync(Guid userId, CancellationToken cancellationToken);
+
+    Task<AnswerResult?> SubmitAnswerAsync(Guid userId, Guid itemId, string submittedAnswer, CancellationToken cancellationToken);
+
+    AnswerResult EvaluateAnswer(DictionaryItem item, string submittedAnswer);
+
+    Task<ProgressDashboard> GetDashboardAsync(Guid userId, CancellationToken cancellationToken);
+}

--- a/apps/api/src/Langoose.Worker/Dockerfile
+++ b/apps/api/src/Langoose.Worker/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY ["apps/api/NuGet.Config", "apps/api/"]
+COPY ["apps/api/src/Langoose.Worker/Langoose.Worker.csproj", "apps/api/src/Langoose.Worker/"]
+COPY ["apps/api/src/Langoose.Core/Langoose.Core.csproj", "apps/api/src/Langoose.Core/"]
+COPY ["apps/api/src/Langoose.Data/Langoose.Data.csproj", "apps/api/src/Langoose.Data/"]
+COPY ["apps/api/src/Langoose.Domain/Langoose.Domain.csproj", "apps/api/src/Langoose.Domain/"]
+RUN dotnet restore "apps/api/src/Langoose.Worker/Langoose.Worker.csproj" --configfile apps/api/NuGet.Config
+
+COPY . .
+RUN dotnet publish "apps/api/src/Langoose.Worker/Langoose.Worker.csproj" -c Release -o /app/publish --no-restore
+
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS final
+WORKDIR /app
+
+COPY --from=build /app/publish .
+
+ENTRYPOINT ["dotnet", "Langoose.Worker.dll"]

--- a/apps/api/src/Langoose.Worker/Langoose.Worker.csproj
+++ b/apps/api/src/Langoose.Worker/Langoose.Worker.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>dotnet-Langoose.Worker-12360230-1dbb-481b-8d6e-21c37c58f168</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Langoose.Core\Langoose.Core.csproj" />
+    <ProjectReference Include="..\Langoose.Domain\Langoose.Domain.csproj" />
+    <ProjectReference Include="..\Langoose.Data\Langoose.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/apps/api/src/Langoose.Worker/Program.cs
+++ b/apps/api/src/Langoose.Worker/Program.cs
@@ -1,0 +1,4 @@
+var builder = Host.CreateApplicationBuilder(args);
+
+var host = builder.Build();
+host.Run();

--- a/apps/api/src/Langoose.Worker/Properties/launchSettings.json
+++ b/apps/api/src/Langoose.Worker/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "Langoose.Worker": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/apps/api/src/Langoose.Worker/appsettings.Development.json
+++ b/apps/api/src/Langoose.Worker/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/apps/api/src/Langoose.Worker/appsettings.json
+++ b/apps/api/src/Langoose.Worker/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/apps/api/tests/Langoose.Api.IntegrationTests/Api/AuthFlowTests.cs
+++ b/apps/api/tests/Langoose.Api.IntegrationTests/Api/AuthFlowTests.cs
@@ -1,6 +1,6 @@
 using System.Net;
-using Langoose.Api.Models;
 using Langoose.Api.IntegrationTests.Infrastructure;
+using Langoose.Api.Models;
 using Xunit;
 
 namespace Langoose.Api.IntegrationTests.Api;

--- a/apps/api/tests/Langoose.Api.IntegrationTests/Api/ProtectedDataFlowTests.cs
+++ b/apps/api/tests/Langoose.Api.IntegrationTests/Api/ProtectedDataFlowTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
-using Langoose.Api.Models;
 using Langoose.Api.IntegrationTests.Infrastructure;
+using Langoose.Api.Models;
 using Langoose.Data;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;

--- a/apps/api/tests/Langoose.Api.IntegrationTests/Infrastructure/ApiTestHost.cs
+++ b/apps/api/tests/Langoose.Api.IntegrationTests/Infrastructure/ApiTestHost.cs
@@ -1,10 +1,11 @@
 using Langoose.Api.Controllers;
 using Langoose.Api.Middleware;
-using Langoose.Api.Services;
 using Langoose.Auth.Data;
 using Langoose.Auth.Data.Models;
+using Langoose.Core.Services;
 using Langoose.Data;
 using Langoose.Data.Seeding;
+using Langoose.Domain.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -67,10 +68,10 @@ internal sealed class ApiTestHost(IHost host) : IAsyncDisposable
                         options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(15);
                     })
                     .AddEntityFrameworkStores<AuthDbContext>();
-                services.AddScoped<EnrichmentService>();
-                services.AddScoped<DictionaryService>();
-                services.AddScoped<StudyService>();
-                services.AddScoped<ContentService>();
+                services.AddScoped<IEnrichmentService, EnrichmentService>();
+                services.AddScoped<IDictionaryService, DictionaryService>();
+                services.AddScoped<IStudyService, StudyService>();
+                services.AddScoped<IContentService, ContentService>();
                 services.AddScoped<DatabaseSeeder>();
                 services.AddControllers()
                     .AddApplicationPart(typeof(DictionaryController).Assembly);

--- a/apps/api/tests/Langoose.Api.IntegrationTests/Infrastructure/TestAppSetup.cs
+++ b/apps/api/tests/Langoose.Api.IntegrationTests/Infrastructure/TestAppSetup.cs
@@ -1,4 +1,4 @@
-using Langoose.Api.Services;
+using Langoose.Core.Services;
 using Langoose.Data;
 using Langoose.Data.Seeding;
 using Microsoft.EntityFrameworkCore;

--- a/apps/api/tests/Langoose.Api.IntegrationTests/Langoose.Api.IntegrationTests.csproj
+++ b/apps/api/tests/Langoose.Api.IntegrationTests/Langoose.Api.IntegrationTests.csproj
@@ -18,5 +18,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Langoose.Api\Langoose.Api.csproj" />
+    <ProjectReference Include="..\..\src\Langoose.Core\Langoose.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/apps/api/tests/Langoose.Api.IntegrationTests/Services/DictionaryServiceIntegrationTests.cs
+++ b/apps/api/tests/Langoose.Api.IntegrationTests/Services/DictionaryServiceIntegrationTests.cs
@@ -1,9 +1,9 @@
-using Langoose.Api.Models;
-using Langoose.Api.Services;
 using Langoose.Api.IntegrationTests.Infrastructure;
+using Langoose.Core.Utilities;
 using Langoose.Data;
 using Langoose.Data.Seeding;
 using Langoose.Domain.Enums;
+using Langoose.Domain.Models;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
@@ -22,8 +22,8 @@ public sealed class DictionaryServiceIntegrationTests
         var seedItems = SeedDataLoader.LoadBaseItems();
 
         Assert.Contains(seedItems, pair => pair.Item.EnglishText == "book" &&
-            pair.Item.RussianGlosses.Contains("книга") &&
-            pair.Sentence.TranslationHint == "Я читаю книгу перед сном.");
+            pair.Item.RussianGlosses.Contains("\u043A\u043D\u0438\u0433\u0430") &&
+            pair.Sentence.TranslationHint == "\u042F \u0447\u0438\u0442\u0430\u044E \u043A\u043D\u0438\u0433\u0443 \u043F\u0435\u0440\u0435\u0434 \u0441\u043D\u043E\u043C.");
         Assert.DoesNotContain(seedItems, pair =>
             pair.Item.RussianGlosses.Any(gloss => gloss.Contains('?')) ||
             pair.Sentence.TranslationHint.Contains('?'));
@@ -73,7 +73,7 @@ public sealed class DictionaryServiceIntegrationTests
 
         var item = await dictionaryService.AddItemAsync(
             userId,
-            new DictionaryItemRequest(
+            new AddItemInput(
                 "look for",
                 ["iskat"],
                 "phrase",
@@ -99,7 +99,7 @@ public sealed class DictionaryServiceIntegrationTests
 
         await dictionaryService.AddItemAsync(
             userId,
-            new DictionaryItemRequest(
+            new AddItemInput(
                 "look for",
                 ["iskat"],
                 "phrase",
@@ -115,7 +115,7 @@ public sealed class DictionaryServiceIntegrationTests
 
         await dictionaryService.AddItemAsync(
             userId,
-            new DictionaryItemRequest(
+            new AddItemInput(
                 " look for ",
                 ["razyskivat"],
                 "phrase",
@@ -146,9 +146,7 @@ public sealed class DictionaryServiceIntegrationTests
         var userId = Guid.NewGuid();
 
         var import = await dictionaryService.ImportCsvAsync(
-            userId,
-            new ImportCsvRequest("words.csv", ValidCsv),
-            CancellationToken.None);
+            userId, ValidCsv, "words.csv", CancellationToken.None);
 
         Assert.Equal(2, import.ImportedRows);
 
@@ -166,14 +164,10 @@ public sealed class DictionaryServiceIntegrationTests
         var userId = Guid.NewGuid();
 
         await dictionaryService.ImportCsvAsync(
-            userId,
-            new ImportCsvRequest("seed.csv", ValidCsv),
-            CancellationToken.None);
+            userId, ValidCsv, "seed.csv", CancellationToken.None);
 
         var duplicateImport = await dictionaryService.ImportCsvAsync(
-            userId,
-            new ImportCsvRequest("duplicates.csv", ValidCsv),
-            CancellationToken.None);
+            userId, ValidCsv, "duplicates.csv", CancellationToken.None);
 
         Assert.Equal(0, duplicateImport.ImportedRows);
         Assert.Equal(2, duplicateImport.SkippedRows);
@@ -189,7 +183,7 @@ public sealed class DictionaryServiceIntegrationTests
 
         await dictionaryService.AddItemAsync(
             userId,
-            new DictionaryItemRequest(
+            new AddItemInput(
                 "improve",
                 ["uluchshat"],
                 "word",
@@ -206,9 +200,7 @@ public sealed class DictionaryServiceIntegrationTests
             " improve ,stanovitsya luchshe,,,";
 
         var duplicateImport = await dictionaryService.ImportCsvAsync(
-            userId,
-            new ImportCsvRequest("variants.csv", variantsCsv),
-            CancellationToken.None);
+            userId, variantsCsv, "variants.csv", CancellationToken.None);
 
         Assert.Equal(0, duplicateImport.ImportedRows);
 
@@ -231,9 +223,7 @@ public sealed class DictionaryServiceIntegrationTests
             "at least,po krayney mere,phrase,,common";
 
         var import = await dictionaryService.ImportCsvAsync(
-            userId,
-            new ImportCsvRequest("base-overlap.csv", csv),
-            CancellationToken.None);
+            userId, csv, "base-overlap.csv", CancellationToken.None);
 
         Assert.Equal(0, import.ImportedRows);
 
@@ -256,8 +246,7 @@ public sealed class DictionaryServiceIntegrationTests
 
         await Assert.ThrowsAsync<ArgumentException>(() =>
             dictionaryService.ImportCsvAsync(
-                userId,
-                new ImportCsvRequest("bad-header.csv", "Word,Translation,Kind\nhello,privet,word"),
+                userId, "Word,Translation,Kind\nhello,privet,word", "bad-header.csv",
                 CancellationToken.None));
     }
 
@@ -275,9 +264,7 @@ public sealed class DictionaryServiceIntegrationTests
             "bad row only two columns,missing";
 
         var result = await dictionaryService.ImportCsvAsync(
-            userId,
-            new ImportCsvRequest("malformed.csv", malformedCsv),
-            CancellationToken.None);
+            userId, malformedCsv, "malformed.csv", CancellationToken.None);
 
         Assert.Equal(0, result.ImportedRows);
         Assert.Single(result.Errors);
@@ -297,7 +284,7 @@ public sealed class DictionaryServiceIntegrationTests
 
         var item = await dictionaryService.AddItemAsync(
             userId,
-            new DictionaryItemRequest(
+            new AddItemInput(
                 "look for",
                 ["iskat"],
                 "phrase",
@@ -309,9 +296,7 @@ public sealed class DictionaryServiceIntegrationTests
             CancellationToken.None);
 
         await studyService.SubmitAnswerAsync(
-            userId,
-            new StudyAnswerRequest(item.Id, "look for"),
-            CancellationToken.None);
+            userId, item.Id, "look for", CancellationToken.None);
 
         await dictionaryService.ClearCustomDataAsync(userId, CancellationToken.None);
         await using var verifyDbContext = await dbContextFactory.CreateDbContextAsync();

--- a/apps/api/tests/Langoose.Api.IntegrationTests/Services/StudyServiceIntegrationTests.cs
+++ b/apps/api/tests/Langoose.Api.IntegrationTests/Services/StudyServiceIntegrationTests.cs
@@ -1,8 +1,7 @@
-using Langoose.Api.Models;
+using Langoose.Api.IntegrationTests.Infrastructure;
 using Langoose.Domain.Constants;
 using Langoose.Domain.Enums;
 using Langoose.Domain.Models;
-using Langoose.Api.IntegrationTests.Infrastructure;
 using Xunit;
 
 namespace Langoose.Api.IntegrationTests.Services;
@@ -18,7 +17,7 @@ public sealed class StudyServiceIntegrationTests
         var studyService = TestAppSetup.CreateStudyService(dbContext);
         var userId = Guid.NewGuid();
 
-        var customItem = await dictionaryService.AddItemAsync(userId, new DictionaryItemRequest(
+        var customItem = await dictionaryService.AddItemAsync(userId, new AddItemInput(
             "look for",
             ["iskat"],
             "phrase",

--- a/apps/api/tests/Langoose.Core.UnitTests/Langoose.Core.UnitTests.csproj
+++ b/apps/api/tests/Langoose.Core.UnitTests/Langoose.Core.UnitTests.csproj
@@ -16,6 +16,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Langoose.Api\Langoose.Api.csproj" />
+    <ProjectReference Include="..\..\src\Langoose.Core\Langoose.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/apps/api/tests/Langoose.Core.UnitTests/Services/EnrichmentServiceTests.cs
+++ b/apps/api/tests/Langoose.Core.UnitTests/Services/EnrichmentServiceTests.cs
@@ -1,8 +1,8 @@
-using Langoose.Api.Models;
-using Langoose.Api.Services;
+using Langoose.Core.Services;
+using Langoose.Domain.Models;
 using Xunit;
 
-namespace Langoose.Api.UnitTests.Services;
+namespace Langoose.Core.UnitTests.Services;
 
 public sealed class EnrichmentServiceTests
 {
@@ -12,7 +12,7 @@ public sealed class EnrichmentServiceTests
         var enrichmentService = new EnrichmentService();
 
         var response = enrichmentService.Enrich(
-            new EnrichmentRequest("mysterious word", ["english gloss"], "phrase"));
+            new EnrichmentInput("mysterious word", ["english gloss"], "phrase"));
 
         Assert.NotEmpty(response.ValidationWarnings);
     }

--- a/apps/api/tests/Langoose.Core.UnitTests/Services/StudyAnswerEvaluationTests.cs
+++ b/apps/api/tests/Langoose.Core.UnitTests/Services/StudyAnswerEvaluationTests.cs
@@ -1,12 +1,11 @@
-using Langoose.Api.Models;
-using Langoose.Api.Services;
+using Langoose.Core.Services;
 using Langoose.Data;
 using Langoose.Domain.Enums;
 using Langoose.Domain.Models;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
-namespace Langoose.Api.UnitTests.Services;
+namespace Langoose.Core.UnitTests.Services;
 
 public sealed class StudyAnswerEvaluationTests
 {

--- a/compose.yml
+++ b/compose.yml
@@ -21,6 +21,17 @@ services:
       postgres:
         condition: service_healthy
 
+  worker:
+    build:
+      context: .
+      dockerfile: apps/api/src/Langoose.Worker/Dockerfile
+    container_name: langoose-worker
+    environment:
+      ConnectionStrings__AppDatabase: Host=postgres;Port=5432;Database=langoose_app;Username=langoose;Password=langoose
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   web:
     build:
       context: ./apps/web

--- a/docs/agent/dotnet-testing.md
+++ b/docs/agent/dotnet-testing.md
@@ -4,7 +4,7 @@
 
 ```mermaid
 flowchart TD
-  Unit["Langoose.Api.UnitTests"] --> Logic["Pure or infrastructure-light logic"]
+  Unit["Langoose.Core.UnitTests"] --> Logic["Pure or infrastructure-light logic"]
   Integration["Langoose.Api.IntegrationTests"] --> Host["Host, persistence, auth, and cross-component behavior"]
   Functional["Langoose.Api.FunctionalTests (optional)"] --> Http["End-to-end HTTP behavior"]
 ```
@@ -13,7 +13,7 @@ flowchart TD
 - Add a third test layer only when unit and integration tests are no longer enough.
 - Avoid rebuilding a catch-all suite that blurs these responsibilities.
 - `apps/api/src/Langoose.Api/Langoose.Api.csproj`
-- `apps/api/tests/Langoose.Api.UnitTests/Langoose.Api.UnitTests.csproj`
+- `apps/api/tests/Langoose.Core.UnitTests/Langoose.Core.UnitTests.csproj`
 - `apps/api/tests/Langoose.Api.IntegrationTests/Langoose.Api.IntegrationTests.csproj`
 
 ## Boundary Rules

--- a/docs/agent/workflows.md
+++ b/docs/agent/workflows.md
@@ -5,7 +5,7 @@
 - Backend build:
   - `dotnet build apps/api/Langoose.sln /p:RestoreConfigFile=apps/api/NuGet.Config`
 - Backend unit tests:
-  - `dotnet test apps/api/tests/Langoose.Api.UnitTests/Langoose.Api.UnitTests.csproj /p:RestoreConfigFile=apps/api/NuGet.Config`
+  - `dotnet test apps/api/tests/Langoose.Core.UnitTests/Langoose.Core.UnitTests.csproj /p:RestoreConfigFile=apps/api/NuGet.Config`
 - Backend integration tests:
   - `dotnet test apps/api/tests/Langoose.Api.IntegrationTests/Langoose.Api.IntegrationTests.csproj /p:RestoreConfigFile=apps/api/NuGet.Config`
 - Run API:
@@ -60,12 +60,21 @@ See `.github/workflows/app-seed.yml` for the hosted workflow.
 ## Repo Reality Check
 
 - Startup and registration live in `apps/api/src/Langoose.Api/Program.cs`.
-- Shared models and abstractions live in `apps/api/src/Langoose.Domain`.
+- Domain models, enums, constants, and service interfaces live in `apps/api/src/Langoose.Domain`.
+- Service implementations and utilities live in `apps/api/src/Langoose.Core`.
 - App data persistence lives in `apps/api/src/Langoose.Data`.
 - Auth persistence lives in `apps/api/src/Langoose.Auth.Data`.
+- Background processing host lives in `apps/api/src/Langoose.Worker`.
 - Database tooling lives in `apps/api/src/Langoose.DbTool`.
 - API contract helpers live in `apps/web/src/api.ts`.
 - The current frontend is centered in `apps/web/src/App.tsx`.
+
+## CI Alignment
+
+GitHub Actions workflows under `.github/workflows/` reference project paths,
+Dockerfile paths, and test project names directly. When a change renames or
+moves a project, Dockerfile, or test assembly, update the affected workflow
+files in the same change to keep CI green.
 
 ## Practical Cautions
 


### PR DESCRIPTION
Closes #69

## Summary

- Extract services from Api into new **Langoose.Core** project with domain-only signatures
- Add **Langoose.Worker** as empty generic host with Dockerfile and compose service
- Add service interfaces (`IDictionaryService`, `IStudyService`, `IContentService`, `IEnrichmentService`) in **Domain/Services**
- Add domain input/result types (`AddItemInput`, `StudyCard`, `AnswerResult`, etc.) in **Domain/Models**
- Controllers now inject interfaces and map DTOs at the API boundary
- Rename unit tests to `Langoose.Core.UnitTests`
- Add `Directory.Build.props` with `EnforceCodeStyleInBuild` enabled
- Apply IDE0305, SYSLIB1045, import ordering, and encoding fixes

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 32/32 pass
- [x] `dotnet format --verify-no-changes` — clean
- [x] `docker compose build api worker` — both succeed