### PR TITLE
Update services for new domain model

### DIFF
--- a/apps/api/src/Langoose.Api/Controllers/StudyController.cs
+++ b/apps/api/src/Langoose.Api/Controllers/StudyController.cs
@@ -33,8 +33,11 @@ public sealed class StudyController(
 
         return Ok(new StudyCardResponse(
             card.DictionaryEntryId,
+            card.EntryContextId,
             card.Prompt,
-            card.TranslationHint,
+            card.SentenceTranslation,
+            card.Translations,
+            card.GrammarHint,
             card.Difficulty));
     }
 
@@ -51,7 +54,7 @@ public sealed class StudyController(
         }
 
         var result = await studyService.SubmitAnswerAsync(
-            user.Id, request.EntryId, request.SubmittedAnswer, cancellationToken);
+            user.Id, request.EntryId, request.EntryContextId, request.SubmittedAnswer, cancellationToken);
 
         if (result is null)
         {

--- a/apps/api/src/Langoose.Api/Models/StudyAnswerRequest.cs
+++ b/apps/api/src/Langoose.Api/Models/StudyAnswerRequest.cs
@@ -1,3 +1,3 @@
 namespace Langoose.Api.Models;
 
-public sealed record StudyAnswerRequest(Guid EntryId, string SubmittedAnswer);
+public sealed record StudyAnswerRequest(Guid EntryId, Guid? EntryContextId, string SubmittedAnswer);

--- a/apps/api/src/Langoose.Api/Models/StudyCardResponse.cs
+++ b/apps/api/src/Langoose.Api/Models/StudyCardResponse.cs
@@ -2,6 +2,9 @@ namespace Langoose.Api.Models;
 
 public sealed record StudyCardResponse(
     Guid DictionaryEntryId,
+    Guid? EntryContextId,
     string Prompt,
-    string TranslationHint,
+    string SentenceTranslation,
+    IReadOnlyList<string> Translations,
+    string? GrammarHint,
     string? Difficulty);

--- a/apps/api/src/Langoose.Core/Services/StudyService.cs
+++ b/apps/api/src/Langoose.Core/Services/StudyService.cs
@@ -152,12 +152,19 @@ public sealed class StudyService(AppDbContext dbContext) : IStudyService
         var evaluation = EvaluateAnswer(entry, submittedAnswer);
         ApplyScheduler(progress, evaluation.Verdict);
 
+        var validatedContextId = entryContextId.HasValue
+            ? await dbContext.EntryContexts
+                .Where(c => c.Id == entryContextId.Value && c.DictionaryEntryId == entryId)
+                .Select(c => (Guid?)c.Id)
+                .FirstOrDefaultAsync(cancellationToken)
+            : null;
+
         dbContext.StudyEvents.Add(new StudyEvent
         {
             Id = Guid.CreateVersion7(),
             UserId = userId,
             DictionaryEntryId = entryId,
-            EntryContextId = entryContextId,
+            EntryContextId = validatedContextId,
             UserInput = submittedAnswer,
             Verdict = evaluation.Verdict,
             FeedbackCode = evaluation.FeedbackCode,

--- a/apps/api/src/Langoose.Core/Services/StudyService.cs
+++ b/apps/api/src/Langoose.Core/Services/StudyService.cs
@@ -61,15 +61,34 @@ public sealed class StudyService(AppDbContext dbContext) : IStudyService
             .ThenBy(p => p.SuccessCount)
             .First();
 
+        var entry = await dbContext.DictionaryEntries
+            .FirstAsync(e => e.Id == next.DictionaryEntryId, cancellationToken);
+
         var context = await dbContext.EntryContexts
             .FirstOrDefaultAsync(c => c.DictionaryEntryId == next.DictionaryEntryId, cancellationToken);
 
-        // TODO: #71 — get translation hint from EntryTranslation
+        var translations = await dbContext.EntryTranslations
+            .Where(t => t.SourceEntryId == next.DictionaryEntryId)
+            .Select(t => t.TargetEntry.Text)
+            .ToListAsync(cancellationToken);
+
+        var sentenceTranslation = "";
+        if (context is not null)
+        {
+            sentenceTranslation = await dbContext.ContextTranslations
+                .Where(ct => ct.SourceContextId == context.Id)
+                .Select(ct => ct.TargetContext.Text)
+                .FirstOrDefaultAsync(cancellationToken) ?? "";
+        }
+
         return new StudyCard(
             next.DictionaryEntryId,
+            context?.Id,
             context?.Cloze ?? "Use ____ in a sentence.",
-            "",
-            next.DictionaryEntry?.Difficulty);
+            sentenceTranslation,
+            translations,
+            entry.GrammarLabel,
+            context?.Difficulty ?? entry.Difficulty);
     }
 
     private async Task<List<Guid>> GetStudyableEntryIdsAsync(Guid userId, CancellationToken cancellationToken)
@@ -98,6 +117,7 @@ public sealed class StudyService(AppDbContext dbContext) : IStudyService
     public async Task<AnswerResult?> SubmitAnswerAsync(
         Guid userId,
         Guid entryId,
+        Guid? entryContextId,
         string submittedAnswer,
         CancellationToken cancellationToken)
     {
@@ -137,6 +157,7 @@ public sealed class StudyService(AppDbContext dbContext) : IStudyService
             Id = Guid.CreateVersion7(),
             UserId = userId,
             DictionaryEntryId = entryId,
+            EntryContextId = entryContextId,
             UserInput = submittedAnswer,
             Verdict = evaluation.Verdict,
             FeedbackCode = evaluation.FeedbackCode,

--- a/apps/api/src/Langoose.Data/Seeding/DatabaseSeeder.cs
+++ b/apps/api/src/Langoose.Data/Seeding/DatabaseSeeder.cs
@@ -16,6 +16,7 @@ public sealed class DatabaseSeeder(AppDbContext dbContext)
         dbContext.DictionaryEntries.AddRange(batch.Entries);
         dbContext.EntryTranslations.AddRange(batch.Translations);
         dbContext.EntryContexts.AddRange(batch.Contexts);
+        dbContext.ContextTranslations.AddRange(batch.ContextTranslations);
 
         await dbContext.SaveChangesAsync(cancellationToken);
     }

--- a/apps/api/src/Langoose.Data/Seeding/SeedDataLoader.cs
+++ b/apps/api/src/Langoose.Data/Seeding/SeedDataLoader.cs
@@ -14,6 +14,7 @@ public static class SeedDataLoader
         var entries = new List<DictionaryEntry>();
         var translations = new List<EntryTranslation>();
         var contexts = new List<EntryContext>();
+        var contextTranslations = new List<ContextTranslation>();
 
         var now = DateTimeOffset.UtcNow;
 
@@ -62,7 +63,7 @@ public static class SeedDataLoader
             });
 
             var sentenceText = item.Cloze.Replace("____", item.English, StringComparison.Ordinal);
-            contexts.Add(new EntryContext
+            var enContext = new EntryContext
             {
                 Id = Guid.CreateVersion7(),
                 DictionaryEntryId = enEntry.Id,
@@ -70,9 +71,9 @@ public static class SeedDataLoader
                 Cloze = item.Cloze,
                 Difficulty = item.Difficulty,
                 CreatedAtUtc = now
-            });
+            };
 
-            contexts.Add(new EntryContext
+            var ruContext = new EntryContext
             {
                 Id = Guid.CreateVersion7(),
                 DictionaryEntryId = ruEntry.Id,
@@ -80,10 +81,26 @@ public static class SeedDataLoader
                 Cloze = item.TranslationHint,
                 Difficulty = item.Difficulty,
                 CreatedAtUtc = now
+            };
+
+            contexts.Add(enContext);
+            contexts.Add(ruContext);
+
+            contextTranslations.Add(new ContextTranslation
+            {
+                SourceContextId = enContext.Id,
+                TargetContextId = ruContext.Id,
+                CreatedAtUtc = now
+            });
+            contextTranslations.Add(new ContextTranslation
+            {
+                SourceContextId = ruContext.Id,
+                TargetContextId = enContext.Id,
+                CreatedAtUtc = now
             });
         }
 
-        return new SeedBatch(entries, translations, contexts);
+        return new SeedBatch(entries, translations, contexts, contextTranslations);
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
@@ -117,4 +134,5 @@ public static class SeedDataLoader
 public sealed record SeedBatch(
     IReadOnlyList<DictionaryEntry> Entries,
     IReadOnlyList<EntryTranslation> Translations,
-    IReadOnlyList<EntryContext> Contexts);
+    IReadOnlyList<EntryContext> Contexts,
+    IReadOnlyList<ContextTranslation> ContextTranslations);

--- a/apps/api/src/Langoose.Domain/Models/StudyCard.cs
+++ b/apps/api/src/Langoose.Domain/Models/StudyCard.cs
@@ -2,6 +2,9 @@ namespace Langoose.Domain.Models;
 
 public sealed record StudyCard(
     Guid DictionaryEntryId,
+    Guid? EntryContextId,
     string Prompt,
-    string TranslationHint,
+    string SentenceTranslation,
+    IReadOnlyList<string> Translations,
+    string? GrammarHint,
     string? Difficulty);

--- a/apps/api/src/Langoose.Domain/Services/IStudyService.cs
+++ b/apps/api/src/Langoose.Domain/Services/IStudyService.cs
@@ -6,7 +6,7 @@ public interface IStudyService
 {
     Task<StudyCard?> GetNextCardAsync(Guid userId, CancellationToken cancellationToken);
 
-    Task<AnswerResult?> SubmitAnswerAsync(Guid userId, Guid entryId, string submittedAnswer, CancellationToken cancellationToken);
+    Task<AnswerResult?> SubmitAnswerAsync(Guid userId, Guid entryId, Guid? entryContextId, string submittedAnswer, CancellationToken cancellationToken);
 
     AnswerResult EvaluateAnswer(DictionaryEntry entry, string submittedAnswer);
 

--- a/apps/api/tests/Langoose.Api.IntegrationTests/Infrastructure/TestAppState.cs
+++ b/apps/api/tests/Langoose.Api.IntegrationTests/Infrastructure/TestAppState.cs
@@ -11,5 +11,6 @@ internal sealed class TestAppState
     public List<UserProgress> UserProgress { get; init; } = [];
     public List<StudyEvent> StudyEvents { get; init; } = [];
     public List<ImportRecord> ImportRecords { get; init; } = [];
+    public List<ContextTranslation> ContextTranslations { get; init; } = [];
     public List<ContentFlag> ContentFlags { get; init; } = [];
 }

--- a/apps/api/tests/Langoose.Api.IntegrationTests/Infrastructure/TestDataSnapshot.cs
+++ b/apps/api/tests/Langoose.Api.IntegrationTests/Infrastructure/TestDataSnapshot.cs
@@ -12,6 +12,7 @@ internal static class TestDataSnapshot
             DictionaryEntries = await dbContext.DictionaryEntries.ToListAsync(cancellationToken),
             EntryTranslations = await dbContext.EntryTranslations.ToListAsync(cancellationToken),
             EntryContexts = await dbContext.EntryContexts.ToListAsync(cancellationToken),
+            ContextTranslations = await dbContext.ContextTranslations.ToListAsync(cancellationToken),
             UserDictionaryEntries = await dbContext.UserDictionaryEntries.ToListAsync(cancellationToken),
             UserProgress = await dbContext.UserProgress.ToListAsync(cancellationToken),
             StudyEvents = await dbContext.StudyEvents.ToListAsync(cancellationToken),

--- a/apps/api/tests/Langoose.Api.IntegrationTests/Services/StudyServiceIntegrationTests.cs
+++ b/apps/api/tests/Langoose.Api.IntegrationTests/Services/StudyServiceIntegrationTests.cs
@@ -92,6 +92,28 @@ public sealed class StudyServiceIntegrationTests
     }
 
     [Fact]
+    public async Task SubmitAnswerAsync_IgnoresMismatchedEntryContextId()
+    {
+        var dbContextFactory = await TestAppSetup.CreateSeededDbContextFactoryAsync();
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync();
+        var studyService = TestAppSetup.CreateStudyService(dbContext);
+        var userId = Guid.NewGuid();
+
+        var store = await TestDataSnapshot.LoadAsync(dbContext);
+        var entry = store.DictionaryEntries.First(e => e.Language == "en" && e.IsPublic);
+        var otherEntry = store.DictionaryEntries.First(e => e.Language == "ru" && e.IsPublic);
+        var wrongContext = store.EntryContexts.First(c => c.DictionaryEntryId == otherEntry.Id);
+
+        var result = await studyService.SubmitAnswerAsync(
+            userId, entry.Id, wrongContext.Id, entry.Text, CancellationToken.None);
+
+        Assert.NotNull(result);
+
+        var studyEvent = dbContext.StudyEvents.First(e => e.UserId == userId);
+        Assert.Null(studyEvent.EntryContextId);
+    }
+
+    [Fact]
     public async Task GetDashboardAsync_CountsOnlyTodaysStudyEvents()
     {
         var dbContextFactory = await TestAppSetup.CreateSeededDbContextFactoryAsync();

--- a/apps/api/tests/Langoose.Api.IntegrationTests/Services/StudyServiceIntegrationTests.cs
+++ b/apps/api/tests/Langoose.Api.IntegrationTests/Services/StudyServiceIntegrationTests.cs
@@ -38,6 +38,60 @@ public sealed class StudyServiceIntegrationTests
     }
 
     [Fact]
+    public async Task GetNextCardAsync_ReturnsTranslationsAndGrammarHint()
+    {
+        var dbContextFactory = await TestAppSetup.CreateSeededDbContextFactoryAsync();
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync();
+        var studyService = TestAppSetup.CreateStudyService(dbContext);
+        var userId = Guid.NewGuid();
+
+        var store = await TestDataSnapshot.LoadAsync(dbContext);
+        var entry = store.DictionaryEntries.First(e => e.Language == "en" && e.IsPublic);
+
+        dbContext.UserProgress.Add(new UserProgress
+        {
+            Id = Guid.CreateVersion7(),
+            UserId = userId,
+            DictionaryEntryId = entry.Id,
+            DueAtUtc = DateTimeOffset.UtcNow.AddMinutes(-5),
+            Stability = ProgressDefaults.InitialStability,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            UpdatedAtUtc = DateTimeOffset.UtcNow
+        });
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var card = await studyService.GetNextCardAsync(userId, CancellationToken.None);
+
+        Assert.NotNull(card);
+        Assert.NotNull(card.EntryContextId);
+        Assert.NotEmpty(card.Translations);
+        Assert.NotNull(card.GrammarHint);
+        Assert.NotEmpty(card.SentenceTranslation);
+    }
+
+    [Fact]
+    public async Task SubmitAnswerAsync_RecordsEntryContextId()
+    {
+        var dbContextFactory = await TestAppSetup.CreateSeededDbContextFactoryAsync();
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync();
+        var studyService = TestAppSetup.CreateStudyService(dbContext);
+        var userId = Guid.NewGuid();
+
+        var store = await TestDataSnapshot.LoadAsync(dbContext);
+        var entry = store.DictionaryEntries.First(e => e.Language == "en" && e.IsPublic);
+        var context = store.EntryContexts.First(c => c.DictionaryEntryId == entry.Id);
+
+        var result = await studyService.SubmitAnswerAsync(
+            userId, entry.Id, context.Id, entry.Text, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(StudyVerdict.Correct, result.Verdict);
+
+        var studyEvent = dbContext.StudyEvents.First(e => e.UserId == userId);
+        Assert.Equal(context.Id, studyEvent.EntryContextId);
+    }
+
+    [Fact]
     public async Task GetDashboardAsync_CountsOnlyTodaysStudyEvents()
     {
         var dbContextFactory = await TestAppSetup.CreateSeededDbContextFactoryAsync();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -239,7 +239,7 @@ export default function App() {
     }
 
     try {
-      const result = await api.submitAnswer(state.card.dictionaryEntryId, answer);
+      const result = await api.submitAnswer(state.card.dictionaryEntryId, answer, state.card.entryContextId);
       const studyState = await loadStudyState();
       setAnswer('');
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -28,8 +28,11 @@ export type DictionaryListItem = {
 
 export type StudyCard = {
   dictionaryEntryId: string;
+  entryContextId?: string | null;
   prompt: string;
-  translationHint: string;
+  sentenceTranslation: string;
+  translations: string[];
+  grammarHint?: string | null;
   difficulty?: string | null;
 };
 
@@ -88,6 +91,7 @@ export type ImportCsvResult = {
 
 export type SubmitAnswerRequest = {
   entryId: string;
+  entryContextId?: string | null;
   submittedAnswer: string;
 };
 
@@ -256,8 +260,8 @@ export const api = {
   getNextCard() {
     return request<StudyCard>('/study/next');
   },
-  submitAnswer(entryId: string, submittedAnswer: string) {
-    const payload: SubmitAnswerRequest = { entryId, submittedAnswer };
+  submitAnswer(entryId: string, submittedAnswer: string, entryContextId?: string | null) {
+    const payload: SubmitAnswerRequest = { entryId, entryContextId, submittedAnswer };
     return request<StudyAnswerResult>('/study/answer', {
       method: 'POST',
       body: JSON.stringify(payload)

--- a/apps/web/src/components/StudyPanel.tsx
+++ b/apps/web/src/components/StudyPanel.tsx
@@ -29,7 +29,11 @@ export function StudyPanel({
           }}
         >
           <p className="prompt">{card.prompt}</p>
-          <p className="hint">{card.translationHint}</p>
+          {card.sentenceTranslation ? <p className="hint">{card.sentenceTranslation}</p> : null}
+          {card.translations.length > 0 ? (
+            <p className="translations">{card.translations.join(', ')}</p>
+          ) : null}
+          {card.grammarHint ? <p className="grammar-hint">{card.grammarHint}</p> : null}
           <input
             value={answer}
             onChange={event => onAnswerChange(event.target.value)}

--- a/docs/agent/workflows.md
+++ b/docs/agent/workflows.md
@@ -28,7 +28,7 @@ Run frontend commands from `apps/web`.
 ## Migrations
 
 Both data projects use `Microsoft.EntityFrameworkCore.Design` and rely on
-`Langoose.Api` as the startup project for design-time context resolution.
+`Langoose.DbTool` as the startup project for design-time context resolution.
 
 ### Creating a migration
 
@@ -75,6 +75,12 @@ GitHub Actions workflows under `.github/workflows/` reference project paths,
 Dockerfile paths, and test project names directly. When a change renames or
 moves a project, Dockerfile, or test assembly, update the affected workflow
 files in the same change to keep CI green.
+
+## Issue and Epic Lifecycle
+
+- Move an issue to "In Progress" on the project board when starting work on it.
+- Move an issue to "In Review" when its PR is created.
+- Move an epic to "In Progress" when any of its sub-issues is being worked on.
 
 ## Practical Cautions
 


### PR DESCRIPTION
Closes #71

## Summary

- Expand `StudyCard` with `EntryContextId`, `SentenceTranslation`, `Translations`, and `GrammarHint` fields
- Load translations via `EntryTranslation` and sentence translations via `ContextTranslation` in `StudyService`
- Record `EntryContextId` on `StudyEvent` when submitting answers (passed through from card → request → event)
- Add `ContextTranslation` seeding so base items have paired EN↔RU sentence translations
- Update API response/request models, frontend types, and `StudyPanel` component
- Add integration tests for study card enrichment fields and `EntryContextId` recording
- Update `docs/agent/workflows.md` with DbTool reference and issue lifecycle section

## Test plan

- [x] All 28 backend tests pass (4 unit + 24 integration, 2 new)
- [x] All 14 frontend tests pass
- [x] Zero build warnings
- [x] TypeScript strict check passes