### PR TITLE
feat(frontend): update frontend for new API responses (#72)

### DIFF
--- a/.codex/skills/langoose-api-contracts/SKILL.md
+++ b/.codex/skills/langoose-api-contracts/SKILL.md
@@ -9,17 +9,25 @@ Read [AGENTS.md](../../../AGENTS.md) first.
 
 Use this skill for any change that crosses the backend/frontend boundary.
 
-## Main Rule
+## Use When
+
+- The task changes controller request or response models.
+- The task changes endpoint behavior that the frontend depends on.
+- The task changes frontend API types, enum serialization, or error shapes.
+
+## Primary Doc
+
+- [api-contracts.md](../../../docs/agent/api-contracts.md)
+
+## Related Docs
+
+- [frontend-conventions.md](../../../docs/agent/frontend-conventions.md)
+
+## Critical Reminders
 
 - Change contract definitions and consumers together.
-
-## Contract Workflow
-
 - Inspect the C# models in `apps/api/src/Langoose.Api/Models`.
 - Inspect the controller actions that expose those models.
 - Inspect the frontend contract layer in `apps/web/src/api.ts`.
+- This skill owns cross-boundary payload and endpoint shape, not general frontend component design or state structure.
 - Update all three when the payload shape or behavior changes.
-
-## Load Additional Detail Only When Needed
-
-- For concrete repo rules and review points, read [api-contracts.md](../../../docs/agent/api-contracts.md).

--- a/.codex/skills/langoose-architecture/SKILL.md
+++ b/.codex/skills/langoose-architecture/SKILL.md
@@ -7,18 +7,28 @@ description: Design or refactor Langoose project boundaries and dependency direc
 
 Read [AGENTS.md](../../../AGENTS.md) first.
 
-Use this skill when the task is about architecture and project boundaries, not just file moves.
+Use this skill when the task is about project boundaries, dependency direction, or structural refactors.
 
-## Main Direction
+## Use When
 
-- Keep the dependency graph simple and explicit.
-- Introduce new projects only when they solve a real ownership or growth problem.
-- Prefer lightweight onion boundaries over ceremony-heavy clean architecture.
+- You are changing project boundaries or references.
+- You are deciding whether a concern belongs in Api, Core, Data, Domain, or Worker.
+- The task is larger than a local file move.
 
-## Workflow
+## Primary Doc
+
+- [architecture.md](../../../docs/agent/architecture.md)
+
+## Related Docs
+
+- [workflows.md](../../../docs/agent/workflows.md)
+
+## Critical Reminders
 
 - Identify the ownership problem first: growth, dependency cycle, tooling confusion, or mixed responsibilities.
 - Choose the smallest project split that fixes that problem.
+- Keep the dependency graph simple and explicit.
+- Prefer lightweight onion boundaries over ceremony-heavy clean architecture.
 - Update solution files, project references, Docker build context, and test references together.
 - Update CI/workflow paths together with the structure change whenever build, test, Docker, or restore commands depend on moved files.
 - Update repo guidance and relevant skills when the architecture decision changes the expected project layout.
@@ -31,9 +41,3 @@ Use this skill when the task is about architecture and project boundaries, not j
   - `dotnet test apps/api/tests/Langoose.Api.IntegrationTests/Langoose.Api.IntegrationTests.csproj /p:RestoreConfigFile=apps/api/NuGet.Config`
 - If Docker or startup wiring changed, verify the live startup path before declaring the architecture work complete.
 - If the refactor created new projects or moved many files, check for mixed line endings before finalizing.
-
-## Load Additional Detail Only When Needed
-
-- For EF Core-specific `API + Data` structure guidance, use [langoose-efcore-structure](../langoose-efcore-structure/SKILL.md).
-- For repo-wide implementation and finish discipline, use [langoose-dev](../langoose-dev/SKILL.md).
-- For the lightweight onion-style recommendations in this repo, read [architecture-guidance.md](../../../docs/agent/architecture-guidance.md).

--- a/.codex/skills/langoose-architecture/references/architecture-guidance.md
+++ b/.codex/skills/langoose-architecture/references/architecture-guidance.md
@@ -1,4 +1,0 @@
-# Canonical Source
-
-The canonical neutral guidance now lives at
-[architecture-guidance.md](../../../../docs/agent/architecture-guidance.md).

--- a/.codex/skills/langoose-auth-hosting/SKILL.md
+++ b/.codex/skills/langoose-auth-hosting/SKILL.md
@@ -9,17 +9,24 @@ Read [AGENTS.md](../../../AGENTS.md) first.
 
 Use this skill when the task touches auth flow, cookie behavior, antiforgery, OpenIddict, forwarded headers, Data Protection, or hosted environment assumptions.
 
-## Main Rule
+## Use When
+
+- The task changes auth cookies, antiforgery, login state, or auth status handling.
+- The task changes proxy, forwarded-header, or hosted environment behavior.
+- The task changes OpenIddict, Data Protection, or auth persistence assumptions.
+
+## Primary Doc
+
+- [auth-hosting.md](../../../docs/agent/auth-hosting.md)
+
+## Related Docs
+
+- [workflows.md](../../../docs/agent/workflows.md)
+
+## Critical Reminders
 
 - Treat auth and hosting behavior as one operational boundary. Do not change cookies, CSRF, proxy trust, or token foundations in isolation.
-
-## Workflow
-
 - Inspect [Program.cs](../../../apps/api/src/Langoose.Api/Program.cs) first.
 - Inspect the auth controllers and integration tests before changing behavior.
 - Keep frontend bootstrap and API expectations aligned when auth status codes, antiforgery flow, or cookie assumptions change.
 - When hosted behavior changes, update the relevant staging or deployment docs in `docs/` in the same change.
-
-## Load Additional Detail Only When Needed
-
-- For canonical repo guidance, read [auth-hosting.md](../../../docs/agent/auth-hosting.md).

--- a/.codex/skills/langoose-dev/SKILL.md
+++ b/.codex/skills/langoose-dev/SKILL.md
@@ -7,16 +7,36 @@ description: Work effectively in the Langoose repository. Use when working acros
 
 Read [AGENTS.md](../../../AGENTS.md) first.
 
-Use this skill as the lightweight router for the repo.
+Use this skill as the repo router when no narrower Langoose skill fits.
+
+## Use When
+
+- The task spans multiple repo areas.
+- You need the repo map, validation commands, or the right next skill.
+
+## Primary Doc
+
+- [workflows.md](../../../docs/agent/workflows.md)
+
+## Related Docs
+
+- [backend-conventions.md](../../../docs/agent/backend-conventions.md)
+- [dotnet-testing.md](../../../docs/agent/dotnet-testing.md)
+- [efcore-structure.md](../../../docs/agent/efcore-structure.md)
+- [architecture.md](../../../docs/agent/architecture.md)
+- [quality-gates.md](../../../docs/agent/quality-gates.md)
+- [git-conventions.md](../../../docs/agent/git-conventions.md)
 
 ## Repo Map
 
-- Keep frontend work inside `apps/web`.
-- Keep backend work inside `apps/api`, with projects under `apps/api/src` and tests under `apps/api/tests`.
-- Treat `Langoose.Data` as app-data persistence and `Langoose.Auth.Data` as auth persistence.
-- Keep auth and hosting docs in [docs](../../../docs) aligned when auth direction changes.
+- Frontend: `apps/web`
+- Backend: `apps/api`
+- Backend projects: `apps/api/src/*`
+- Backend tests: `apps/api/tests`
+- App persistence: `apps/api/src/Langoose.Data`
+- Auth persistence: `apps/api/src/Langoose.Auth.Data`
 
-## Use Narrower Skills When They Fit
+## Route To Narrower Skills When They Fit
 
 - `langoose-dotnet-testing` for backend test layout and test-boundary decisions.
 - `langoose-auth-hosting` for auth flow, cookies, antiforgery, OpenIddict, forwarded headers, and hosted behavior.
@@ -27,15 +47,13 @@ Use this skill as the lightweight router for the repo.
 - `langoose-docker` for Docker and Compose.
 - `langoose-architecture` for project-boundary refactors.
 - `langoose-efcore-structure` for EF Core and migrations layout.
+- `langoose-quality-gates` for file hygiene, validation lanes, and CI alignment.
+- `langoose-workflows` for build, run, validation, and migration commands.
+- `langoose-git-conventions` for branch, commit, PR, issue, and project workflow.
 
-## Finish Cleanly
+## Critical Reminders
 
 - Run the smallest relevant build, test, and acceptance checks.
 - Prefer the containerized path for whole-app, startup, persistence, or auth verification.
 - If a validation lane is blocked, report the gap plainly.
 - If repo reality changed, update the affected skill or doc before finishing.
-
-## Load Additional Detail Only When Needed
-
-- For commands and repo-specific validation, read [workflows.md](../../../docs/agent/workflows.md).
-- For test-boundary rationale, also read [backend-test-strategy.md](../../../docs/backend-test-strategy.md).

--- a/.codex/skills/langoose-dev/references/workflows.md
+++ b/.codex/skills/langoose-dev/references/workflows.md
@@ -1,4 +1,0 @@
-# Canonical Source
-
-The canonical neutral guidance now lives at
-[workflows.md](../../../../docs/agent/workflows.md).

--- a/.codex/skills/langoose-dictionary-imports/SKILL.md
+++ b/.codex/skills/langoose-dictionary-imports/SKILL.md
@@ -9,17 +9,24 @@ Read [AGENTS.md](../../../AGENTS.md) first.
 
 Use this skill when dictionary rules or CSV workflows are involved.
 
-## Main Rule
+## Use When
+
+- The task changes dictionary visibility or merge behavior.
+- The task changes quick add, CSV import/export, or duplicate handling.
+- The task changes related frontend contract or UI behavior.
+
+## Primary Doc
+
+- [dictionary-rules.md](../../../docs/agent/dictionary-rules.md)
+
+## Related Docs
+
+- [api-contracts.md](../../../docs/agent/api-contracts.md)
+
+## Critical Reminders
 
 - Preserve dictionary visibility and duplicate-collapsing invariants unless the task explicitly changes them.
-
-## Workflow
-
-- Inspect `apps/api/src/Langoose.Api/Services/DictionaryService.cs`.
+- Inspect `apps/api/src/Langoose.Core/Services/DictionaryService.cs`.
 - Inspect `apps/api/src/Langoose.Api/Controllers/DictionaryController.cs`.
 - Inspect the corresponding frontend calls in `apps/web/src/api.ts` and UI behavior in `apps/web/src/App.tsx`.
 - Inspect the relevant backend tests under `apps/api/tests` before changing behavior.
-
-## Load Additional Detail Only When Needed
-
-- For concrete repo rules and review points, read [dictionary-rules.md](../../../docs/agent/dictionary-rules.md).

--- a/.codex/skills/langoose-dictionary-imports/references/dictionary-rules.md
+++ b/.codex/skills/langoose-dictionary-imports/references/dictionary-rules.md
@@ -1,4 +1,0 @@
-# Canonical Source
-
-The canonical neutral guidance now lives at
-[dictionary-rules.md](../../../../docs/agent/dictionary-rules.md).

--- a/.codex/skills/langoose-docker/SKILL.md
+++ b/.codex/skills/langoose-docker/SKILL.md
@@ -9,21 +9,28 @@ Read [AGENTS.md](../../../AGENTS.md) first.
 
 Use this skill when the task involves Docker, Compose, or containerized local development.
 
-## Main Rules
+## Use When
+
+- The task adds or edits Dockerfiles, Compose, or containerized dev flow.
+- The task needs container validation for startup, persistence, auth, or cross-app wiring.
+
+## Primary Doc
+
+- [docker-guidance.md](../../../docs/agent/docker-guidance.md)
+
+## Related Docs
+
+- [workflows.md](../../../docs/agent/workflows.md)
+- [quality-gates.md](../../../docs/agent/quality-gates.md)
+
+## Critical Reminders
 
 - Containerize the API and web app as separate concerns.
 - Use multi-stage builds for production-style images.
 - Add `.dockerignore` files or root exclusions to keep build contexts small.
 - Keep Dockerfiles environment-agnostic. Put runtime-specific values in Compose or external env configuration.
-
-## Workflow
-
 - Decide whether the task is dev-only containers, production-style images, or both.
 - Inspect `apps/api` and `apps/web` build/run commands before writing Dockerfiles.
 - Add `.dockerignore` alongside Docker support so image contexts do not include `node_modules`, `bin`, `obj`, `.git`, or runtime data.
 - If Compose is used, prefer health-aware dependency wiring instead of blind startup ordering.
 - When changing persistence or startup wiring, verify the full container path: database healthy, API starts, migrations or schema creation actually run, and the key user flow succeeds through HTTP.
-
-## Load Additional Detail Only When Needed
-
-- For Docker and Compose best practices mapped to this repo, read [docker-guidance.md](../../../docs/agent/docker-guidance.md).

--- a/.codex/skills/langoose-docker/references/docker-guidance.md
+++ b/.codex/skills/langoose-docker/references/docker-guidance.md
@@ -1,4 +1,0 @@
-# Canonical Source
-
-The canonical neutral guidance now lives at
-[docker-guidance.md](../../../../docs/agent/docker-guidance.md).

--- a/.codex/skills/langoose-dotnet-testing/SKILL.md
+++ b/.codex/skills/langoose-dotnet-testing/SKILL.md
@@ -9,20 +9,27 @@ Read [AGENTS.md](../../../AGENTS.md) first.
 
 Use this skill when the task is mainly about .NET test structure, test boundaries, or ASP.NET Core test patterns.
 
-## Organize By Test Type First
+## Use When
+
+- You are choosing between unit, integration, and functional coverage.
+- You are moving or reorganizing backend tests.
+- You are setting up or reviewing ASP.NET Core host-based tests.
+
+## Primary Doc
+
+- [dotnet-testing.md](../../../docs/agent/dotnet-testing.md)
+
+## Related Docs
+
+- [quality-gates.md](../../../docs/agent/quality-gates.md)
+
+## Critical Reminders
 
 - Keep unit tests isolated from file system and other infrastructure.
 - Keep integration tests for persistence and cross-component behavior.
 - Keep functional tests for end-to-end HTTP behavior against the app host.
 - Do not put infrastructure-heavy tests in the unit-test project.
 - If a test only uses lightweight framework objects incidentally while proving isolated logic, keep it with the shallowest layer that still matches the real risk.
-
-## Organize Inside A Test Project
-
 - Group tests by the application area they exercise, such as `Services`, `Controllers`, or a specific feature slice.
 - Use folders and namespaces when many tests target the same class or feature.
 - Prefer clear test names that describe method, scenario, and expected behavior.
-
-## Load Additional Detail Only When Needed
-
-- For the rationale and concrete repo conventions, read [dotnet-testing.md](../../../docs/agent/dotnet-testing.md).

--- a/.codex/skills/langoose-dotnet-testing/references/layout-and-test-types.md
+++ b/.codex/skills/langoose-dotnet-testing/references/layout-and-test-types.md
@@ -1,4 +1,0 @@
-# Canonical Source
-
-The canonical neutral guidance now lives at
-[dotnet-testing.md](../../../../docs/agent/dotnet-testing.md).

--- a/.codex/skills/langoose-efcore-structure/SKILL.md
+++ b/.codex/skills/langoose-efcore-structure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: langoose-efcore-structure
-description: Design or refactor Langoose EF Core and PostgreSQL structure. Use when deciding project boundaries, moving persistence into a separate data project, organizing DbContext and migrations, splitting entity configuration classes, or defining EF Core conventions for apps/api and related data projects.
+description: Design or refactor Langoose EF Core and PostgreSQL structure. Use when organizing DbContext and migrations, splitting entity configuration classes, defining EF Core conventions, or refining persistence layout inside the existing backend structure.
 ---
 
 # Langoose EF Core Structure
@@ -9,30 +9,39 @@ Read [AGENTS.md](../../../AGENTS.md) first.
 
 Use this skill when the task is about EF Core structure rather than day-to-day feature work.
 
-## Main Direction
+## Use When
+
+- The task changes `DbContext`, entity configuration, migrations, or seeding layout.
+- The task changes EF conventions or tooling setup.
+- The task changes persistence layout inside the existing backend structure.
+
+## Primary Doc
+
+- [efcore-structure.md](../../../docs/agent/efcore-structure.md)
+
+## Related Docs
+
+- [workflows.md](../../../docs/agent/workflows.md)
+- [quality-gates.md](../../../docs/agent/quality-gates.md)
+
+## Critical Reminders
 
 - Prefer a separate data project when the PostgreSQL and EF Core layer is expected to grow.
-- If persisted models need a shared home outside ASP.NET Core and EF Core, use `API + Domain + Data`.
 - Preserve existing business rules and public API behavior while moving persistence structure around.
-
-## Structure Rules
-
 - Keep EF-specific concerns out of controllers.
-- Keep service-layer business rules in `apps/api/src/Langoose.Api/Services`, even if persistence types move out.
+- Keep service-layer business rules in `apps/api/src/Langoose.Core/Services`, even if persistence types move out.
 - Keep shared persisted models in `apps/api/src/Langoose.Domain` when both API behavior and EF Core depend on them, but avoid carrying broad persistence-container abstractions there once services can use focused EF access directly.
 - Prefer one `IEntityTypeConfiguration<T>` file per entity once mappings are no longer tiny.
 - Prefer `ApplyConfigurationsFromAssembly` in `DbContext` over a large inline mapping file.
 - Keep the startup project explicit for EF tooling and runtime configuration.
-- Do not split into a separate migrations project by default; use `API + Domain + Data` before adding a fourth boundary unless the task explicitly needs it.
 - After moving or creating persistence files, normalize line endings immediately and verify that the new files do not contain mixed newlines.
 
 ## Workflow
 
 - Inspect the current persistence files before moving them.
-- Decide whether the change is only folder and namespace cleanup or a real project split.
-- If introducing or splitting data projects, move EF runtime files together: `DbContext`, design-time factory, configurations, migrations, and seeding types.
-- If the persistence types are shared beyond EF, move them into `apps/api/src/Langoose.Domain` instead of keeping them under the API project.
-- Update startup wiring, project references, namespaces, design-time tooling, and CI or workflow paths together.
+- Decide whether the change is only folder and namespace cleanup or a targeted persistence-layout change.
+- Move EF runtime files together when needed: `DbContext`, design-time factory, configurations, migrations, and seeding types.
+- Update startup wiring, namespaces, design-time tooling, and CI or workflow paths together when persistence files move.
 - Update repo guidance and skills if the persistence layout changes.
 
 ## Validation
@@ -40,12 +49,5 @@ Use this skill when the task is about EF Core structure rather than day-to-day f
 - Run the current backend tests:
   - `dotnet test apps/api/tests/Langoose.Core.UnitTests/Langoose.Core.UnitTests.csproj /p:RestoreConfigFile=apps/api/NuGet.Config`
   - `dotnet test apps/api/tests/Langoose.Api.IntegrationTests/Langoose.Api.IntegrationTests.csproj /p:RestoreConfigFile=apps/api/NuGet.Config`
-- If project boundaries changed, also build the affected projects or solution explicitly.
 - If startup or migrations wiring changed, verify the live container or local startup path before declaring the structure work complete.
 - Before finalizing, run an explicit line-ending check on the new Domain and Data files so Visual Studio does not surface inconsistent newline prompts.
-
-## Load Additional Detail Only When Needed
-
-- For repo-wide working agreements and finish flow, use [langoose-dev](../langoose-dev/SKILL.md).
-- For ASP.NET Core and EF-adjacent framework guidance, use the shared `aspnet-core` skill when it is available in the current Codex environment.
-- For the recommended Langoose layout and tradeoffs, read [efcore-structure.md](../../../docs/agent/efcore-structure.md).

--- a/.codex/skills/langoose-efcore-structure/agents/openai.yaml
+++ b/.codex/skills/langoose-efcore-structure/agents/openai.yaml
@@ -1,4 +1,4 @@
 version: 1
 display_name: Langoose EF Core Structure
-short_description: Design the Langoose API and data-project boundary for EF Core and PostgreSQL work.
-default_prompt: Use this skill when deciding or refactoring Langoose EF Core structure, including separate data projects, DbContext placement, entity configuration files, migrations layout, and persistence adapter boundaries.
+short_description: Organize Langoose EF Core and PostgreSQL structure within the existing backend layout.
+default_prompt: Use this skill when refactoring Langoose EF Core structure, including DbContext placement, entity configuration files, migrations layout, seeding structure, and EF tooling conventions inside the current backend architecture.

--- a/.codex/skills/langoose-efcore-structure/references/structure-guidance.md
+++ b/.codex/skills/langoose-efcore-structure/references/structure-guidance.md
@@ -1,4 +1,0 @@
-# Canonical Source
-
-The canonical neutral guidance now lives at
-[efcore-structure.md](../../../../docs/agent/efcore-structure.md).

--- a/.codex/skills/langoose-git-conventions/SKILL.md
+++ b/.codex/skills/langoose-git-conventions/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: langoose-git-conventions
+description: Follow the canonical Langoose Git, branch, PR, and issue workflow. Use when starting work, naming branches or commits, creating PRs, or keeping issue and project state aligned.
+---
+
+# Langoose Git Conventions
+
+Read [AGENTS.md](../../../AGENTS.md) first.
+
+Use this skill when the task is primarily about Git workflow, issue/PR lifecycle, or naming conventions in this repository.
+
+## Use When
+
+- You are starting or publishing work on an issue.
+- You need the right branch or commit naming pattern.
+- You need to keep issue, PR, and project-board state aligned.
+
+## Primary Doc
+
+- [git-conventions.md](../../../docs/agent/git-conventions.md)
+
+## Related Docs
+
+- [workflows.md](../../../docs/agent/workflows.md)
+- [quality-gates.md](../../../docs/agent/quality-gates.md)
+
+## Critical Reminders
+
+- Start new work from the latest `main`.
+- Use one focused branch per issue or tightly related change whenever practical.
+- Follow the repo’s branch and commit naming conventions.
+- Keep issue, PR, and project state aligned with the real state of the work.
+- Use squash merge into `main`.

--- a/.codex/skills/langoose-quality-gates/SKILL.md
+++ b/.codex/skills/langoose-quality-gates/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: langoose-quality-gates
+description: Apply the canonical Langoose finish criteria, file hygiene, validation expectations, and CI alignment rules. Use when deciding what must be validated or updated before work is truly done.
+---
+
+# Langoose Quality Gates
+
+Read [AGENTS.md](../../../AGENTS.md) first.
+
+Use this skill when the task is primarily about file hygiene, finish criteria, validation scope, or CI alignment.
+
+## Use When
+
+- You need to decide which checks a change must pass.
+- You need to know whether CI, docs, workflows, or contracts must be updated together.
+- You are reviewing whether work is ready to consider done.
+
+## Primary Doc
+
+- [quality-gates.md](../../../docs/agent/quality-gates.md)
+
+## Related Docs
+
+- [workflows.md](../../../docs/agent/workflows.md)
+- [git-conventions.md](../../../docs/agent/git-conventions.md)
+
+## Critical Reminders
+
+- This skill answers "what must be validated or updated before completion?" not "what command should I run right now?"
+- Run the smallest relevant build, test, and acceptance checks for the change.
+- Validate every CI lane the change will trigger, not just the convenient local ones.
+- When paths, Dockerfiles, test assemblies, or contracts move, update the affected workflows and docs in the same change.
+- If a lane is blocked or fails, say so plainly and do not report it as passing by inference.

--- a/.codex/skills/langoose-react-typescript/SKILL.md
+++ b/.codex/skills/langoose-react-typescript/SKILL.md
@@ -9,16 +9,28 @@ Read [AGENTS.md](../../../AGENTS.md) first.
 
 Use this skill when the task is primarily in `apps/web` or when frontend API types and UI behavior need to stay aligned.
 
-## Preferred Frontend Style
+## Use When
+
+- The task is mainly in `apps/web`.
+- The task changes component state, effects, event handling, or TS API types.
+- The task changes frontend behavior that depends on backend contract shape.
+
+## Primary Doc
+
+- [frontend-conventions.md](../../../docs/agent/frontend-conventions.md)
+
+## Related Docs
+
+- [api-contracts.md](../../../docs/agent/api-contracts.md)
+
+## Critical Reminders
 
 - Keep components pure during render.
 - Prefer deriving values during render instead of storing redundant state.
 - Prefer event handlers for user-driven work.
 - Use effects only when synchronizing with external systems such as browser APIs, network lifecycle edges, or subscriptions.
 - Keep API contracts explicit in TypeScript rather than pushing shape uncertainty into component code.
-
-## Langoose-Specific Guidance
-
+- This skill owns frontend implementation and type usage, not backend/frontend contract ownership.
 - The current app is centered in [App.tsx](../../../apps/web/src/App.tsx). Preserve simplicity, but split code when a feature or model becomes hard to follow.
 - Keep the typed API surface in [api.ts](../../../apps/web/src/api.ts) aligned with backend contract changes.
 - Prefer narrow request payload types over `Record<string, unknown>` where the payload shape is known.
@@ -31,7 +43,3 @@ Use this skill when the task is primarily in `apps/web` or when frontend API typ
 - Prefer explicit unions and domain types over stringly typed helpers when practical.
 - Prefer `unknown` plus narrowing over `any`.
 - Add stricter TSConfig options only when the repo is ready to absorb the resulting fixes.
-
-## Load Additional Detail Only When Needed
-
-- For React principles, TypeScript options, and repo-specific frontend recommendations, read [frontend-guidance.md](../../../docs/agent/frontend-guidance.md).

--- a/.codex/skills/langoose-react-typescript/references/frontend-guidance.md
+++ b/.codex/skills/langoose-react-typescript/references/frontend-guidance.md
@@ -1,4 +1,0 @@
-# Canonical Source
-
-The canonical neutral guidance now lives at
-[frontend-guidance.md](../../../../docs/agent/frontend-guidance.md).

--- a/.codex/skills/langoose-study-engine/SKILL.md
+++ b/.codex/skills/langoose-study-engine/SKILL.md
@@ -9,17 +9,24 @@ Read [AGENTS.md](../../../AGENTS.md) first.
 
 Use this skill for study-loop behavior and grading logic.
 
-## Main Rule
+## Use When
+
+- The task changes grading, normalization, scheduling, or card selection.
+- The task changes dashboard counts or study response behavior.
+- The task changes tests around study-loop rules.
+
+## Primary Doc
+
+- [study-engine.md](../../../docs/agent/study-engine.md)
+
+## Related Docs
+
+- [dotnet-testing.md](../../../docs/agent/dotnet-testing.md)
+
+## Critical Reminders
 
 - Treat grading and scheduling as product rules, not incidental implementation details.
-
-## Workflow
-
-- Inspect `apps/api/src/Langoose.Api/Services/StudyService.cs`.
-- Inspect `apps/api/src/Langoose.Api/Services/TextNormalizer.cs` when matching or tolerance behavior is involved.
+- Inspect `apps/api/src/Langoose.Core/Services/StudyService.cs`.
+- Inspect `apps/api/src/Langoose.Core/Utilities/TextNormalizer.cs` when matching or tolerance behavior is involved.
 - Inspect the relevant tests under `apps/api/tests`, especially the unit and integration coverage around study behavior.
 - Update tests whenever the grading or scheduling contract changes intentionally.
-
-## Load Additional Detail Only When Needed
-
-- For concrete study rules and review points, read [study-engine.md](../../../docs/agent/study-engine.md).

--- a/.codex/skills/langoose-study-engine/references/study-rules.md
+++ b/.codex/skills/langoose-study-engine/references/study-rules.md
@@ -1,4 +1,0 @@
-# Canonical Source
-
-The canonical neutral guidance now lives at
-[study-engine.md](../../../../docs/agent/study-engine.md).

--- a/.codex/skills/langoose-workflows/SKILL.md
+++ b/.codex/skills/langoose-workflows/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: langoose-workflows
+description: Use the canonical Langoose build, run, startup, and migration commands. Use when you need the right repo command, startup path, container flow, or migration command for work in this repository.
+---
+
+# Langoose Workflows
+
+Read [AGENTS.md](../../../AGENTS.md) first.
+
+Use this skill when the task is primarily about repo commands, startup flow, container flow, or migration commands.
+
+## Use When
+
+- You need the right build, test, run, Docker, or E2E command.
+- You need the right local or container command to execute a change safely.
+- You need the correct EF migration command or startup project.
+
+## Primary Doc
+
+- [workflows.md](../../../docs/agent/workflows.md)
+
+## Related Docs
+
+- [quality-gates.md](../../../docs/agent/quality-gates.md)
+- [efcore-structure.md](../../../docs/agent/efcore-structure.md)
+- [docker-guidance.md](../../../docs/agent/docker-guidance.md)
+
+## Critical Reminders
+
+- This skill answers "what command or runtime path should I use?" not "what must be proven before merge?"
+- Prefer whole-app container commands when the change affects startup, persistence, auth, or cross-app behavior.
+- If a command path is blocked, report the gap plainly instead of inferring success.
+- When a change affects migrations, use `Langoose.DbTool` as the startup project for EF commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,73 +18,7 @@
 - Prefer small changes that fit the current architecture before introducing new layers or abstractions.
 - Keep business rules on the backend when they affect grading, dictionary visibility, imports, scheduling, auth, or persistence.
 - Prefer first-class integrations for hosted reads and metadata when they are available and reliable. Use local `git` for workspace branch management.
-- Keep repo guidance in sync with reality. If a change updates architecture, auth direction, test layout, Docker flow, or core commands, update the affected skill or doc in the same change.
-
-## File Hygiene
-
-- Respect [`.gitattributes`](.gitattributes) and [`.editorconfig`](.editorconfig).
-- Keep files UTF-8, preserve non-ASCII product text safely, and avoid line-ending-only churn.
-- Prefer a 120-character line length unless the file format or local readability clearly justifies an exception.
-- Do not leave stray leading blank lines at the top of source, config, solution, or documentation files.
-- When editing Markdown under `docs/`, verify links relative to the file's real directory.
-
-## C# Conventions
-
-- Prefer one top-level type per file.
-- Prefer primary constructors when they simplify the type.
-- Prefer `record` or `record struct` for DTOs and other value-like data carriers when identity semantics are unnecessary.
-- Keep namespaces aligned with the project and folder structure.
-- Keep public and protected members before private helpers.
-- Prefer names that are clear in local scope without adding unnecessary noise.
-- Avoid redundant materialization, qualification, imports, and DI registrations.
-- Replace non-obvious magic numbers with named constants or configuration.
-
-## React And TypeScript Conventions
-
-- Keep React components pure during render.
-- Prefer derived state over duplicated state.
-- Prefer event handlers for user-driven logic and use effects only for real external synchronization.
-- Keep `strict` TypeScript and prefer precise domain types over broad fallback shapes.
-- Prefer the current lightweight frontend style by default: plain React state plus plain CSS unless the change clearly needs more.
-
-## Product Invariants
-
-- The product is for Russian speakers learning English.
-- Visible dictionary items must collapse duplicate normalized English terms across base and custom sources.
-- Quick add and CSV import must merge duplicate custom entries instead of multiplying them.
-- Terms already in the base dictionary should stay visible as a single base-backed item.
-- CSV import must remain strict about header order and must not partially import malformed input.
-- Study grading is intentionally tolerant for exact matches, known variants, missing articles, inflection mismatches, and minor typos.
-- Clearing custom data must not revoke active sessions.
-
-## Validation
-
-- Run the smallest relevant build, test, and acceptance checks for the change.
-- Prefer containerized whole-app validation when the change affects startup, persistence, auth, or cross-app behavior.
-- If a validation lane is blocked or fails, say so plainly and do not report it as passing by inference.
-- When a change renames or moves a project, Dockerfile, or test assembly, update the affected GitHub Actions workflows, contributor commands, and repo guidance docs in the same change.
-- When a change touches domain entities, DbContext, or EF configurations, generate or update the EF migration in the same change. In-memory tests do not validate migrations.
-- When a change alters API endpoints, request shapes, or response shapes, update the frontend API types and calls in the same change. Backend tests do not validate frontend contract alignment.
-- Validate every CI lane the change will trigger — not just the lanes that are convenient to run locally.
-
-## Workflow
-
-- Check the live GitHub state before answering "what's next" or starting issue work.
-- Start new work from the latest `main`.
-- Use one focused branch per issue or tightly related change whenever practical.
-- Keep issue, PR, and project state aligned with the real state of the work.
-- Use squash merge into `main`.
-- When creating sub-issues for an epic, link them as real GitHub sub-issues using the `addSubIssue` GraphQL mutation — not just checklist text in the epic body.
-- Assign the repo owner to every new issue and epic.
-
-### Branch Naming
-
-- `docs/...` for documentation and repo guidance.
-- `infra/...` for CI, Docker, deployment, and workflow changes.
-- `feat/...` for product or implementation work.
-- `fix/...` for bug fixes.
-- `chore/...` for maintenance.
-
+- Keep repo guidance in sync with reality. If a change updates architecture, auth direction, test layout, Docker flow, or core commands, update the affected doc in the same change.
 
 ## Guidance Index
 
@@ -95,20 +29,46 @@ Keep this table in sync when adding or removing docs under `docs/agent/`.
 
 | Doc | Scope |
 |-----|-------|
-| `docs/agent/architecture-guidance.md` | Onion layers (Domain, Core, Data, Api, Worker), project boundaries, dependency direction |
-| `docs/agent/enrichment-guidance.md` | DictionaryEntry, EntryContext, async enrichment pipeline, LLM provider, batch processing |
-| `docs/agent/dictionary-rules.md` | DictionaryEntry/UserDictionaryEntry visibility, form-based dedup, CSV import/export |
-| `docs/agent/study-engine.md` | Sentence-based study cards, UserProgress, answer evaluation via Levenshtein, scheduling |
+| `docs/agent/architecture.md` | Onion layers, project boundaries, dependency direction, anti-goals |
+| `docs/agent/backend-conventions.md` | C# style conventions |
 | `docs/agent/efcore-structure.md` | Entities, Guid v7, composite PKs, DbContext, migrations, entity config, seeding |
-| `docs/agent/api-contracts.md` | DTO mapping pattern, request/response models, controller payloads, frontend API types |
-| `docs/agent/frontend-guidance.md` | React components, state, effects, TypeScript config, API integration |
-| `docs/agent/auth-hosting.md` | Auth cookies, antiforgery, OpenIddict, forwarded headers, hosting |
-| `docs/agent/dotnet-testing.md` | Test layout, unit vs integration boundaries, test hosts |
-| `docs/agent/docker-guidance.md` | Dockerfiles, Compose, containerized dev |
-| `docs/agent/workflows.md` | Build/test commands, key file locations, validation |
+| `docs/agent/dotnet-testing.md` | Test layout, unit vs integration boundaries, test organization |
+| `docs/agent/frontend-conventions.md` | React patterns, TypeScript config, CSS approach |
+| `docs/agent/api-contracts.md` | DTO mapping, response shapes, frontend type alignment |
+| `docs/agent/dictionary-rules.md` | Visibility, form-based dedup, CSV import/export, product invariants |
+| `docs/agent/study-engine.md` | Study cards, answer evaluation, grading tolerances, scheduling |
+| `docs/agent/enrichment-guidance.md` | Provider interface, worker, content generation, rate limiting |
+| `docs/agent/auth-hosting.md` | Cookies, antiforgery, OpenIddict, proxy, Data Protection |
+| `docs/agent/docker-guidance.md` | Dockerfiles, Compose, E2E testing |
+| `docs/agent/git-conventions.md` | Commits, branches, PRs, issue lifecycle, git hygiene |
+| `docs/agent/quality-gates.md` | File hygiene, validation, CI alignment, practical cautions |
+| `docs/agent/workflows.md` | Build/test/run commands, migration commands |
 
+
+## Skill Mapping
+
+| Doc | Owner | Notes |
+|-----|-------|-------|
+| `docs/agent/architecture.md` | `langoose-architecture` | |
+| `docs/agent/backend-conventions.md` | `doc-only` | C# style; links to efcore-structure and dotnet-testing |
+| `docs/agent/efcore-structure.md` | `langoose-efcore-structure` | |
+| `docs/agent/dotnet-testing.md` | `langoose-dotnet-testing` | |
+| `docs/agent/frontend-conventions.md` | `langoose-react-typescript` | |
+| `docs/agent/api-contracts.md` | `langoose-api-contracts` | |
+| `docs/agent/dictionary-rules.md` | `langoose-dictionary-imports` | |
+| `docs/agent/study-engine.md` | `langoose-study-engine` | |
+| `docs/agent/enrichment-guidance.md` | `doc-only` | No dedicated skill yet |
+| `docs/agent/auth-hosting.md` | `langoose-auth-hosting` | |
+| `docs/agent/docker-guidance.md` | `langoose-docker` | |
+| `docs/agent/git-conventions.md` | `langoose-git-conventions` | |
+| `docs/agent/quality-gates.md` | `langoose-quality-gates` | |
+| `docs/agent/workflows.md` | `langoose-workflows` | langoose-dev also uses this as primary |
 
 ## Skill Index
+
+Skills are lightweight operational wrappers, not the canonical policy store.
+When skill text and `docs/agent/` ever disagree, align the skill to the doc or
+update the doc first if repo reality changed.
 
 - Use [langoose-dev](.codex/skills/langoose-dev/SKILL.md) for general repo work or when no narrower skill clearly applies.
 - Use [langoose-auth-hosting](.codex/skills/langoose-auth-hosting/SKILL.md) for auth flow, cookies, antiforgery, OpenIddict, forwarded headers, and hosted environment behavior.
@@ -120,3 +80,6 @@ Keep this table in sync when adding or removing docs under `docs/agent/`.
 - Use [langoose-docker](.codex/skills/langoose-docker/SKILL.md) for Docker and Compose work.
 - Use [langoose-architecture](.codex/skills/langoose-architecture/SKILL.md) for project-boundary refactors.
 - Use [langoose-efcore-structure](.codex/skills/langoose-efcore-structure/SKILL.md) for EF Core structure and migrations layout.
+- Use [langoose-quality-gates](.codex/skills/langoose-quality-gates/SKILL.md) for file hygiene, validation lanes, and CI alignment.
+- Use [langoose-workflows](.codex/skills/langoose-workflows/SKILL.md) for build, run, validation, and migration commands.
+- Use [langoose-git-conventions](.codex/skills/langoose-git-conventions/SKILL.md) for branch, commit, PR, issue, and project workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,73 +18,7 @@
 - Prefer small changes that fit the current architecture before introducing new layers or abstractions.
 - Keep business rules on the backend when they affect grading, dictionary visibility, imports, scheduling, auth, or persistence.
 - Prefer first-class integrations for hosted reads and metadata when they are available and reliable. Use local `git` for workspace branch management.
-- Keep repo guidance in sync with reality. If a change updates architecture, auth direction, test layout, Docker flow, or core commands, update the affected skill or doc in the same change.
-
-## File Hygiene
-
-- Respect [`.gitattributes`](.gitattributes) and [`.editorconfig`](.editorconfig).
-- Keep files UTF-8, preserve non-ASCII product text safely, and avoid line-ending-only churn.
-- Prefer a 120-character line length unless the file format or local readability clearly justifies an exception.
-- Do not leave stray leading blank lines at the top of source, config, solution, or documentation files.
-- When editing Markdown under `docs/`, verify links relative to the file's real directory.
-
-## C# Conventions
-
-- Prefer one top-level type per file.
-- Prefer primary constructors when they simplify the type.
-- Prefer `record` or `record struct` for DTOs and other value-like data carriers when identity semantics are unnecessary.
-- Keep namespaces aligned with the project and folder structure.
-- Keep public and protected members before private helpers.
-- Prefer names that are clear in local scope without adding unnecessary noise.
-- Avoid redundant materialization, qualification, imports, and DI registrations.
-- Replace non-obvious magic numbers with named constants or configuration.
-
-## React And TypeScript Conventions
-
-- Keep React components pure during render.
-- Prefer derived state over duplicated state.
-- Prefer event handlers for user-driven logic and use effects only for real external synchronization.
-- Keep `strict` TypeScript and prefer precise domain types over broad fallback shapes.
-- Prefer the current lightweight frontend style by default: plain React state plus plain CSS unless the change clearly needs more.
-
-## Product Invariants
-
-- The product is for Russian speakers learning English.
-- Visible dictionary items must collapse duplicate normalized English terms across base and custom sources.
-- Quick add and CSV import must merge duplicate custom entries instead of multiplying them.
-- Terms already in the base dictionary should stay visible as a single base-backed item.
-- CSV import must remain strict about header order and must not partially import malformed input.
-- Study grading is intentionally tolerant for exact matches, known variants, missing articles, inflection mismatches, and minor typos.
-- Clearing custom data must not revoke active sessions.
-
-## Validation
-
-- Run the smallest relevant build, test, and acceptance checks for the change.
-- Prefer containerized whole-app validation when the change affects startup, persistence, auth, or cross-app behavior.
-- If a validation lane is blocked or fails, say so plainly and do not report it as passing by inference.
-- When a change renames or moves a project, Dockerfile, or test assembly, update the affected GitHub Actions workflows, contributor commands, and repo guidance docs in the same change.
-- When a change touches domain entities, DbContext, or EF configurations, generate or update the EF migration in the same change. In-memory tests do not validate migrations.
-- When a change alters API endpoints, request shapes, or response shapes, update the frontend API types and calls in the same change. Backend tests do not validate frontend contract alignment.
-- Validate every CI lane the change will trigger — not just the lanes that are convenient to run locally.
-
-## Workflow
-
-- Check the live GitHub state before answering "what's next" or starting issue work.
-- Start new work from the latest `main`.
-- Use one focused branch per issue or tightly related change whenever practical.
-- Keep issue, PR, and project state aligned with the real state of the work.
-- Use squash merge into `main`.
-- When creating sub-issues for an epic, link them as real GitHub sub-issues using the `addSubIssue` GraphQL mutation — not just checklist text in the epic body.
-- Assign the repo owner to every new issue and epic.
-
-### Branch Naming
-
-- `docs/...` for documentation and repo guidance.
-- `infra/...` for CI, Docker, deployment, and workflow changes.
-- `feat/...` for product or implementation work.
-- `fix/...` for bug fixes.
-- `chore/...` for maintenance.
-
+- Keep repo guidance in sync with reality. If a change updates architecture, auth direction, test layout, Docker flow, or core commands, update the affected doc in the same change.
 
 ## Guidance Index
 
@@ -95,14 +29,17 @@ Keep this table in sync when adding or removing docs under `docs/agent/`.
 
 | Doc | Scope |
 |-----|-------|
-| `docs/agent/architecture-guidance.md` | Onion layers (Domain, Core, Data, Api, Worker), project boundaries, dependency direction |
-| `docs/agent/enrichment-guidance.md` | DictionaryEntry, EntryContext, async enrichment pipeline, LLM provider, batch processing |
-| `docs/agent/dictionary-rules.md` | DictionaryEntry/UserDictionaryEntry visibility, form-based dedup, CSV import/export |
-| `docs/agent/study-engine.md` | Sentence-based study cards, UserProgress, answer evaluation via Levenshtein, scheduling |
+| `docs/agent/architecture.md` | Onion layers, project boundaries, dependency direction, anti-goals |
+| `docs/agent/backend-conventions.md` | C# style conventions |
 | `docs/agent/efcore-structure.md` | Entities, Guid v7, composite PKs, DbContext, migrations, entity config, seeding |
-| `docs/agent/api-contracts.md` | DTO mapping pattern, request/response models, controller payloads, frontend API types |
-| `docs/agent/frontend-guidance.md` | React components, state, effects, TypeScript config, API integration |
-| `docs/agent/auth-hosting.md` | Auth cookies, antiforgery, OpenIddict, forwarded headers, hosting |
-| `docs/agent/dotnet-testing.md` | Test layout, unit vs integration boundaries, test hosts |
-| `docs/agent/docker-guidance.md` | Dockerfiles, Compose, containerized dev |
-| `docs/agent/workflows.md` | Build/test commands, key file locations, validation |
+| `docs/agent/dotnet-testing.md` | Test layout, unit vs integration boundaries, test organization |
+| `docs/agent/frontend-conventions.md` | React patterns, TypeScript config, CSS approach |
+| `docs/agent/api-contracts.md` | DTO mapping, response shapes, frontend type alignment |
+| `docs/agent/dictionary-rules.md` | Visibility, form-based dedup, CSV import/export, product invariants |
+| `docs/agent/study-engine.md` | Study cards, answer evaluation, grading tolerances, scheduling |
+| `docs/agent/enrichment-guidance.md` | Provider interface, worker, content generation, rate limiting |
+| `docs/agent/auth-hosting.md` | Cookies, antiforgery, OpenIddict, proxy, Data Protection |
+| `docs/agent/docker-guidance.md` | Dockerfiles, Compose, E2E testing |
+| `docs/agent/git-conventions.md` | Commits, branches, PRs, issue lifecycle, git hygiene |
+| `docs/agent/quality-gates.md` | File hygiene, validation, CI alignment, practical cautions |
+| `docs/agent/workflows.md` | Build/test/run commands, migration commands |

--- a/apps/web/src/components/DictionaryPanel.tsx
+++ b/apps/web/src/components/DictionaryPanel.tsx
@@ -1,5 +1,13 @@
 import type { AuthResponse, DictionaryListItem } from '../api';
 
+function statusPillClass(entry: DictionaryListItem): string {
+  if (entry.isPublic) return '';
+  if (entry.enrichmentStatus === 'pending') return 'pill-pending';
+  if (entry.enrichmentStatus === 'failed') return 'pill-failed';
+  if (entry.enrichmentStatus === 'enriched') return 'pill-enriched';
+  return '';
+}
+
 type DictionaryPanelProps = {
   auth?: AuthResponse;
   customEntryCount: number;
@@ -36,7 +44,7 @@ export function DictionaryPanel({
               <strong>{entry.text}</strong>
             </div>
             <div className="pill-row">
-              <span>{entry.isPublic ? 'base' : entry.enrichmentStatus ?? 'custom'}</span>
+              <span className={statusPillClass(entry)}>{entry.isPublic ? 'base' : entry.enrichmentStatus ?? 'custom'}</span>
               <span>{entry.type ?? 'word'}</span>
               {entry.difficulty ? <span>{entry.difficulty}</span> : null}
             </div>

--- a/apps/web/src/components/StudyPanel.tsx
+++ b/apps/web/src/components/StudyPanel.tsx
@@ -34,6 +34,7 @@ export function StudyPanel({
             <p className="translations">{card.translations.join(', ')}</p>
           ) : null}
           {card.grammarHint ? <p className="grammar-hint">{card.grammarHint}</p> : null}
+          {card.difficulty ? <span className="difficulty-badge">{card.difficulty}</span> : null}
           <input
             value={answer}
             onChange={event => onAnswerChange(event.target.value)}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -251,6 +251,32 @@ form {
   letter-spacing: 0.08em;
 }
 
+.pill-row .pill-pending {
+  background: rgba(193, 107, 0, 0.12);
+  color: var(--warn);
+}
+
+.pill-row .pill-enriched {
+  background: rgba(47, 143, 91, 0.12);
+  color: var(--good);
+}
+
+.pill-row .pill-failed {
+  background: rgba(199, 73, 73, 0.12);
+  color: var(--bad);
+}
+
+.difficulty-badge {
+  display: inline-block;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(31, 42, 47, 0.08);
+  color: var(--muted);
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+}
+
 .error-banner,
 .notice-banner {
   padding: 14px 18px;

--- a/docs/agent/api-contracts.md
+++ b/docs/agent/api-contracts.md
@@ -31,17 +31,22 @@ controllers don't go through Core services.
 - The frontend mirrors API enums as string unions.
 - The frontend request helper treats `202` and `204` as no-body responses and handles
   CSV as `text/csv`.
+- Controllers return flat DTOs (not raw domain models). The frontend never needs to
+  understand the DictionaryEntry/UserDictionaryEntry/EntryTranslation split — the API
+  flattens it.
 
 ## Key Response Shapes
 
 - **Dictionary items**: flat DTO combining DictionaryEntry + UserDictionaryEntry +
-  EntryTranslation data. Includes `enrichmentStatus`.
+  EntryTranslation data. Includes `enrichmentStatus` for pending/enriched/failed display.
 - **Study cards**: includes `cloze` (from EntryContext), sentence translation
   (from paired context via ContextTranslation), `translations` (from
   EntryTranslation), `grammarHint` (from DictionaryEntry.GrammarLabel),
   `difficulty` (from EntryContext).
-- **Import response**: includes `pendingEnrichment` count.
+- **Import response**: includes `pendingCount`.
 - **Study answer result**: includes `entryContextId` for context tracking.
+- When pending items exist, poll the dictionary endpoint on an interval to refresh
+  status. Stop polling when no items are pending.
 
 ## Review Checklist
 

--- a/docs/agent/architecture.md
+++ b/docs/agent/architecture.md
@@ -1,4 +1,4 @@
-# Langoose Architecture Guidance
+# Langoose Architecture
 
 ## Principle
 

--- a/docs/agent/backend-conventions.md
+++ b/docs/agent/backend-conventions.md
@@ -1,0 +1,17 @@
+# Backend Conventions
+
+## C# Style
+
+- Prefer one top-level type per file.
+- Prefer primary constructors when they simplify the type.
+- Prefer `record` or `record struct` for DTOs and other value-like data carriers when identity semantics are unnecessary.
+- Keep namespaces aligned with the project and folder structure.
+- Keep public and protected members before private helpers.
+- Prefer names that are clear in local scope without adding unnecessary noise.
+- Avoid redundant materialization, qualification, imports, and DI registrations.
+- Replace non-obvious magic numbers with named constants or configuration.
+
+## Related Canonical Docs
+
+- For EF structure, migrations, and seeding, read [efcore-structure.md](efcore-structure.md).
+- For backend test boundaries and organization, read [dotnet-testing.md](dotnet-testing.md).

--- a/docs/agent/dotnet-testing.md
+++ b/docs/agent/dotnet-testing.md
@@ -1,37 +1,32 @@
-# Langoose .NET Test Layout
+# .NET Testing
 
-## Current Shape
+## Test Projects
 
-```mermaid
-flowchart TD
-  Unit["Langoose.Core.UnitTests"] --> Logic["Pure or infrastructure-light logic"]
-  Integration["Langoose.Api.IntegrationTests"] --> Host["Host, persistence, auth, and cross-component behavior"]
-  Functional["Langoose.Api.FunctionalTests (optional)"] --> Http["End-to-end HTTP behavior"]
-```
-
-- Keep test boundaries organized by what kind of risk they prove.
-- Add a third test layer only when unit and integration tests are no longer enough.
-- Avoid rebuilding a catch-all suite that blurs these responsibilities.
-- `apps/api/src/Langoose.Api/Langoose.Api.csproj`
-- `apps/api/tests/Langoose.Core.UnitTests/Langoose.Core.UnitTests.csproj`
-- `apps/api/tests/Langoose.Api.IntegrationTests/Langoose.Api.IntegrationTests.csproj`
+- `apps/api/tests/Langoose.Core.UnitTests` — pure or infrastructure-light logic.
+- `apps/api/tests/Langoose.Api.IntegrationTests` — host, persistence, auth, and cross-component behavior.
+- `Langoose.Api.FunctionalTests` (optional) — add only if unit and integration tests are no longer enough.
 
 ## Boundary Rules
 
 - Keep unit tests focused on infrastructure-light logic.
 - Keep integration tests for persistence, host, auth, and cross-component behavior.
-- Add `Langoose.Api.FunctionalTests` only if a third boundary becomes useful.
-- If a test mainly proves isolated logic, a lightweight incidental dependency on framework objects does not automatically force it upward into integration.
+- If a test mainly proves isolated logic, a lightweight incidental dependency on
+  framework objects does not automatically force it upward into integration.
+- Keep `Api` integration tests for request-pipeline, auth, antiforgery, routing,
+  and serialization behavior.
+- Keep `Services` integration tests for EF-backed backend behavior where HTTP is
+  not the primary risk.
+- Do not add persistence-only tests unless they prove something the broader
+  integration tests do not already prove.
 
-## Internal Organization
+## Organization
 
 - Group tests by feature or application area.
 - Use clear test names that describe method, scenario, and expected behavior.
 - Keep application references one-way: test projects reference app projects.
 
-## Repo-Specific Notes
+## Review Checklist
 
-- Integration tests can still be split internally by `Api` and `Services`.
-- Keep `Api` integration tests for request-pipeline, auth, antiforgery, routing, and serialization behavior.
-- Keep `Services` integration tests for EF-backed backend behavior where HTTP is not the primary risk.
-- Do not add persistence-only tests unless they prove something the broader integration tests do not already prove.
+- Does the test prove the right risk boundary (unit vs integration)?
+- Is this infrastructure-heavy test in the right project?
+- Does this add signal beyond broader integration coverage that already exists?

--- a/docs/agent/efcore-structure.md
+++ b/docs/agent/efcore-structure.md
@@ -1,11 +1,4 @@
-# Langoose EF Core Structure Guidance
-
-## Layout
-
-- `apps/api/src/Langoose.Domain` — entity classes, enums, constants.
-- `apps/api/src/Langoose.Data` — `AppDbContext`, entity configurations, migrations, seeding.
-- `apps/api/src/Langoose.Auth.Data` — auth `DbContext`, auth configuration, auth migrations.
-- `apps/api/src/Langoose.Core` — services that use `AppDbContext` directly.
+# EF Core Structure
 
 ## Entities
 
@@ -18,18 +11,18 @@ better for B-tree indexing in PostgreSQL). Mapping tables use composite primary 
 |--------|-------|-------------------|
 | DictionaryEntry | dictionary_entries | Self-ref BaseEntryId, has many EntryContexts |
 | EntryTranslation | entry_translations | Composite PK (SourceEntryId, TargetEntryId) |
-| EntryContext | entry_contexts | FK → DictionaryEntry |
+| EntryContext | entry_contexts | FK -> DictionaryEntry |
 | ContextTranslation | context_translations | Composite PK (SourceContextId, TargetContextId) |
-| UserDictionaryEntry | user_dictionary_entries | FK → DictionaryEntry (nullable) |
-| UserEntryContext | user_entry_contexts | FK → UserDictionaryEntry |
-| UserProgress | user_progress | FK → DictionaryEntry. Unique (UserId, DictionaryEntryId) |
-| StudyEvent | study_events | FK → DictionaryEntry, FK → EntryContext (nullable) |
-| ContentFlag | content_flags | FK → DictionaryEntry |
+| UserDictionaryEntry | user_dictionary_entries | FK -> DictionaryEntry (nullable) |
+| UserEntryContext | user_entry_contexts | FK -> UserDictionaryEntry |
+| UserProgress | user_progress | FK -> DictionaryEntry. Unique (UserId, DictionaryEntryId) |
+| StudyEvent | study_events | FK -> DictionaryEntry, FK -> EntryContext (nullable) |
+| ContentFlag | content_flags | FK -> DictionaryEntry |
 | ImportRecord | import_records | No FKs to content tables |
 
 ### Auth Database (AuthDbContext)
 
-Unchanged. Contains `AuthUser`, `AuthSession`, and OpenIddict tables.
+Contains `AuthUser`, `AuthSession`, and OpenIddict tables. Unchanged by domain reworks.
 
 ## Conventions
 

--- a/docs/agent/frontend-conventions.md
+++ b/docs/agent/frontend-conventions.md
@@ -1,25 +1,15 @@
-# Langoose Frontend Guidance
+# Frontend Conventions
 
 ## Defaults
 
 - The app uses `React.StrictMode` in `apps/web/src/main.tsx`.
-- Avoid state in `apps/web/src/App.tsx` that merely mirrors other known values.
+- Keep React components pure during render.
+- Prefer derived state over duplicated state — avoid state that merely mirrors other known values.
+- Prefer event handlers for user-driven logic; use effects only for real external synchronization.
 - Prefer named request and response shapes in `apps/web/src/api.ts`.
 - Update `apps/web/src/api.ts` first when backend contracts evolve.
 - Prefer the current lightweight frontend style: plain React state plus plain CSS
   unless the change clearly needs more.
-
-## API Integration
-
-- Controllers return flat DTOs (not raw domain models). The frontend never needs to
-  understand the DictionaryEntry/UserDictionaryEntry/EntryTranslation split — the API
-  flattens it.
-- Dictionary item responses include `enrichmentStatus` for pending/enriched/failed display.
-- Study card responses include: `cloze`, sentence translation (from paired context),
-  `translations` (word-level from EntryTranslation), `grammarHint` (from
-  DictionaryEntry.GrammarLabel), `difficulty` (from EntryContext).
-- When pending items exist, poll the dictionary endpoint on an interval to refresh status.
-  Stop polling when no items are pending.
 
 ## TypeScript
 

--- a/docs/agent/git-conventions.md
+++ b/docs/agent/git-conventions.md
@@ -1,0 +1,52 @@
+# Git Conventions
+
+## Issue and Epic Lifecycle
+
+- Move an issue to "In Progress" on the project board **before writing any code** — this is step zero.
+- If the issue is a sub-issue of an epic, move the epic to "In Progress" too (if not already).
+- Move an issue to "In Review" when its PR is created.
+- After merge, verify the project board moves the issue to "Done".
+
+## Naming Conventions
+
+### Commits
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
+`<type>[optional scope]: <description>`. Common types: `feat`, `fix`, `docs`,
+`refactor`, `test`, `chore`, `infra`. Use a scope when the change targets a
+specific layer or area, e.g. `feat(study):`, `fix(api):`.
+
+### Branches
+
+Use the conventional type as prefix, then the issue number, then a short
+kebab-case description: `<type>/<number>-<description>`.
+
+- `docs/42-enrichment-guidance`
+- `infra/55-docker-compose-pg`
+- `feat/72-update-frontend-new-api`
+- `fix/30-cancellation-tokens`
+- `chore/99-dependency-updates`
+
+### PR Titles
+
+Use the same conventional type prefix as commits:
+`<type>[optional scope]: <description> (#<number>)`.
+
+Do not add AI attribution lines (Co-Authored-By, "Generated with Claude Code")
+to commits or PRs.
+
+## Git Hygiene
+
+- Always use `git add -A` when staging. Never cherry-pick files by name — all
+  changed files are part of the commit, including `.claude/settings.local.json`.
+- Before creating a PR, check `gh pr list --head <branch>` first. The branch
+  may already have a PR from a previous session.
+- When creating a PR, set assignee, labels, and milestone to match the linked
+  issue.
+- Use squash merge into `main`.
+- Start new work from the latest `main`.
+- Use one focused branch per issue or tightly related change whenever practical.
+- When creating sub-issues for an epic, link them as real GitHub sub-issues
+  using the `addSubIssue` GraphQL mutation — not just checklist text in the
+  epic body.
+- Assign the repo owner to every new issue and epic.

--- a/docs/agent/git-conventions.md
+++ b/docs/agent/git-conventions.md
@@ -37,8 +37,8 @@ to commits or PRs.
 
 ## Git Hygiene
 
-- Always use `git add -A` when staging. Never cherry-pick files by name — all
-  changed files are part of the commit, including `.claude/settings.local.json`.
+- Review `git status` before committing to avoid pulling in unrelated or
+  machine-specific files from a dirty worktree.
 - Before creating a PR, check `gh pr list --head <branch>` first. The branch
   may already have a PR from a previous session.
 - When creating a PR, set assignee, labels, and milestone to match the linked

--- a/docs/agent/quality-gates.md
+++ b/docs/agent/quality-gates.md
@@ -1,0 +1,34 @@
+# Quality Gates
+
+## File Hygiene
+
+- Respect [`.gitattributes`](../../.gitattributes) and [`.editorconfig`](../../.editorconfig).
+- Keep files UTF-8, preserve non-ASCII product text safely, and avoid line-ending-only churn.
+- Prefer a 120-character line length unless the file format or local readability clearly justifies an exception.
+- Do not leave stray leading blank lines at the top of source, config, solution, or documentation files.
+- When editing Markdown under `docs/`, verify links relative to the file's real directory.
+
+## Validation
+
+- Run the smallest relevant build, test, and acceptance checks for the change.
+- Prefer containerized whole-app validation when the change affects startup, persistence, auth, or cross-app behavior.
+- If a validation lane is blocked or fails, say so plainly and do not report it as passing by inference.
+- When a change renames or moves a project, Dockerfile, or test assembly, update the affected GitHub Actions workflows, contributor commands, and repo guidance docs in the same change.
+- When a change touches domain entities, DbContext, or EF configurations, generate or update the EF migration in the same change. In-memory tests do not validate migrations.
+- When a change alters API endpoints, request shapes, or response shapes, update the frontend API types and calls in the same change. Backend tests do not validate frontend contract alignment.
+- Validate every CI lane the change will trigger — not just the lanes that are convenient to run locally.
+- Resolve code inspection and style analyzer warnings in the affected files before considering work done.
+
+## CI Alignment
+
+GitHub Actions workflows under `.github/workflows/` reference project paths,
+Dockerfile paths, and test project names directly. When a change renames or
+moves a project, Dockerfile, or test assembly, update the affected workflow
+files in the same change to keep CI green.
+
+## Practical Cautions
+
+- Avoid relying on `bin`, `obj`, `.vs`, `.dotnet`, and `node_modules` as if they were source files.
+- If a change touches API behavior, inspect tests under `apps/api/tests` because they encode product decisions clearly.
+- If frontend and backend contracts move together, update `apps/web/src/api.ts` in the same change.
+- For auth, cookie, antiforgery, OpenIddict, forwarded-header, or hosted environment changes, use `langoose-auth-hosting` and keep the related `docs/` guidance aligned.

--- a/docs/agent/study-engine.md
+++ b/docs/agent/study-engine.md
@@ -37,14 +37,16 @@ Difficulty:         "B1"                                (from EntryContext.Diffi
 
 ## Answer Evaluation
 
-Compare user input against the linked DictionaryEntry.Text (the expected form):
+Grading is intentionally tolerant. Compare user input against the linked
+DictionaryEntry.Text (the expected form):
 - Levenshtein similarity via TextNormalizer for typo tolerance
 - Missing articles, inflection variants tolerated as AlmostCorrect
+- Accepted known variants (e.g. "colour" vs "color") as Correct
 - Record EntryContextId in StudyEvent for per-context analytics
 
 ### Verdicts
 
-- `Correct` — exact match or near-exact
+- `Correct` — exact match, near-exact, or accepted variant
 - `AlmostCorrect` — minor typo, missing article, inflection variant
 - `Incorrect` — meaning mismatch
 

--- a/docs/agent/workflows.md
+++ b/docs/agent/workflows.md
@@ -10,11 +10,11 @@
   - `dotnet test apps/api/tests/Langoose.Api.IntegrationTests/Langoose.Api.IntegrationTests.csproj /p:RestoreConfigFile=apps/api/NuGet.Config`
 - Run API:
   - `dotnet run --project apps/api/src/Langoose.Api/Langoose.Api.csproj`
-- Frontend build:
+- Frontend build (from `apps/web`):
   - `npm run build`
-- Frontend tests:
+- Frontend tests (from `apps/web`):
   - `npm run test`
-- Frontend dev:
+- Frontend dev (from `apps/web`):
   - `npm run dev`
 - Whole app:
   - `docker compose up -d postgres`
@@ -23,68 +23,7 @@
 - E2E tests (requires the whole app running):
   - `docker compose --profile e2e up --build e2e`
 
-Run frontend commands from `apps/web`.
-
 ## Migrations
 
-Both data projects use `Microsoft.EntityFrameworkCore.Design` and rely on
-`Langoose.DbTool` as the startup project for design-time context resolution.
-
-### Creating a migration
-
-App database (`AppDbContext` in `Langoose.Data`):
-
-```
-dotnet ef migrations add <MigrationName> --project apps/api/src/Langoose.Data --startup-project apps/api/src/Langoose.DbTool --context AppDbContext
-```
-
-Auth database (`AuthDbContext` in `Langoose.Auth.Data`):
-
-```
-dotnet ef migrations add <MigrationName> --project apps/api/src/Langoose.Auth.Data --startup-project apps/api/src/Langoose.DbTool --context AuthDbContext
-```
-
-### Applying migrations
-
-- **Local / Docker**: the API applies migrations automatically on startup.
-- **Staging / Production**: migrations are applied explicitly before deploy via
-  `Langoose.DbTool` (`apply-app-migrations`, `apply-auth-migrations`).
-  See `.github/workflows/app-db-migrations.yml` and `auth-db-migrations.yml`.
-
-### Seeding
-
-Base content seeding uses `Langoose.DbTool seed-app`. It is empty-database-only —
-run it only when the app database is brand new or has been recreated.
-See `.github/workflows/app-seed.yml` for the hosted workflow.
-
-## Repo Reality Check
-
-- Startup and registration live in `apps/api/src/Langoose.Api/Program.cs`.
-- Domain models, enums, constants, and service interfaces live in `apps/api/src/Langoose.Domain`.
-- Service implementations and utilities live in `apps/api/src/Langoose.Core`.
-- App data persistence lives in `apps/api/src/Langoose.Data`.
-- Auth persistence lives in `apps/api/src/Langoose.Auth.Data`.
-- Background processing host lives in `apps/api/src/Langoose.Worker`.
-- Database tooling lives in `apps/api/src/Langoose.DbTool`.
-- API contract helpers live in `apps/web/src/api.ts`.
-- The current frontend is centered in `apps/web/src/App.tsx`.
-
-## CI Alignment
-
-GitHub Actions workflows under `.github/workflows/` reference project paths,
-Dockerfile paths, and test project names directly. When a change renames or
-moves a project, Dockerfile, or test assembly, update the affected workflow
-files in the same change to keep CI green.
-
-## Issue and Epic Lifecycle
-
-- Move an issue to "In Progress" on the project board when starting work on it.
-- Move an issue to "In Review" when its PR is created.
-- Move an epic to "In Progress" when any of its sub-issues is being worked on.
-
-## Practical Cautions
-
-- Avoid relying on `bin`, `obj`, `.vs`, `.dotnet`, and `node_modules` as if they were source files.
-- If a change touches API behavior, inspect tests under `apps/api/tests` because they encode product decisions clearly.
-- If frontend and backend contracts move together, update `apps/web/src/api.ts` in the same change.
-- For auth, cookie, antiforgery, OpenIddict, forwarded-header, or hosted environment changes, use `langoose-auth-hosting` and keep the related `docs/` guidance aligned.
+See [efcore-structure.md](efcore-structure.md) for migration commands, EF
+conventions, entity details, and seeding.

--- a/scripts/sync-rules.ps1
+++ b/scripts/sync-rules.ps1
@@ -210,6 +210,7 @@ function Audit {
     Test-IndexLinks -Path $agentsPath -Marker $guidanceMarker -Label "AGENTS Guidance Index"
     Test-IndexLinks -Path $agentsPath -Marker $agentsSkillMarker -Label "AGENTS Skill Index"
     Test-IndexLinks -Path $claudePath -Marker $guidanceMarker -Label "CLAUDE Guidance Index"
+    & (Join-Path $repoRoot "scripts/validate-skill-doc-map.ps1")
 }
 
 function Reconcile {

--- a/scripts/sync-rules.sh
+++ b/scripts/sync-rules.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
-AGENTS_SKILL_MARKER="## Skill Index"
+AGENTS_SKILL_MARKER="## Skill Mapping"
 GUIDANCE_MARKER="## Guidance Index"
 CLAUDE_SPECIFIC_MARKER="## Claude-Specific Notes"
 
@@ -176,8 +176,10 @@ audit_index_links() {
 
 audit() {
   audit_index_links AGENTS.md "${GUIDANCE_MARKER}" "AGENTS Guidance Index"
-  audit_index_links AGENTS.md "${AGENTS_SKILL_MARKER}" "AGENTS Skill Index"
+  audit_index_links AGENTS.md "${AGENTS_SKILL_MARKER}" "AGENTS Skill Mapping"
+  audit_index_links AGENTS.md "## Skill Index" "AGENTS Skill Index"
   audit_index_links CLAUDE.md "${GUIDANCE_MARKER}" "CLAUDE Guidance Index"
+  scripts/validate-skill-doc-map.sh
 }
 
 reconcile() {

--- a/scripts/validate-skill-doc-map.ps1
+++ b/scripts/validate-skill-doc-map.ps1
@@ -1,0 +1,193 @@
+param()
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (git rev-parse --show-toplevel).Trim()
+Set-Location $repoRoot
+
+$agentsPath = Join-Path $repoRoot "AGENTS.md"
+$skillsRoot = Join-Path $repoRoot ".codex/skills"
+$docsRoot = Join-Path $repoRoot "docs/agent"
+
+function Fail {
+    param([string]$Message)
+    Write-Error $Message
+    exit 2
+}
+
+function Parse-OwnershipTable {
+    $text = Get-Content $agentsPath -Raw
+    $marker = "## Skill Mapping"
+    $index = $text.IndexOf($marker)
+    if ($index -lt 0) {
+        Fail "AGENTS.md is missing the '## Skill Mapping' section."
+    }
+
+    $section = $text.Substring($index) -split "`r?`n"
+    $rows = @()
+    $inTable = $false
+
+    foreach ($line in $section) {
+        if ($line -match '^\| Doc \| Owner \| Notes \|$') {
+            $inTable = $true
+            continue
+        }
+
+        if (-not $inTable) {
+            continue
+        }
+
+        if ($line -match '^\|[-| ]+\|$') {
+            continue
+        }
+
+        if (-not $line.StartsWith("|")) {
+            break
+        }
+
+        $parts = $line.Trim('|').Split('|').ForEach({ $_.Trim() })
+        if ($parts.Count -ne 3) {
+            Fail "Malformed ownership row in AGENTS.md: $line"
+        }
+
+        $doc = $parts[0].Trim('`')
+        $owner = $parts[1].Trim('`')
+        $notes = $parts[2]
+
+        $rows += [pscustomobject]@{
+            Doc = $doc
+            Owner = $owner
+            Notes = $notes
+        }
+    }
+
+    if ($rows.Count -eq 0) {
+        Fail "AGENTS.md Skill Mapping table is empty."
+    }
+
+    return $rows
+}
+
+function Get-PrimaryDoc {
+    param([string]$SkillPath)
+
+    $lines = Get-Content $SkillPath
+    $primaryIndex = [Array]::IndexOf($lines, "## Primary Doc")
+    if ($primaryIndex -lt 0) {
+        Fail "$SkillPath is missing a '## Primary Doc' section."
+    }
+
+    $docs = @()
+    for ($i = $primaryIndex + 1; $i -lt $lines.Length; $i++) {
+        $line = $lines[$i]
+        if ($line -match '^## ') {
+            break
+        }
+
+        if ($line -match '^\s*-\s+\[.+\]\(([^)]+)\)\s*$') {
+            $docs += $Matches[1]
+        }
+    }
+
+    if ($docs.Count -ne 1) {
+        Fail "$SkillPath must list exactly one primary doc, found $($docs.Count)."
+    }
+
+    return $docs[0]
+}
+
+function Resolve-RepoRelativeFromFile {
+    param(
+        [string]$BaseFile,
+        [string]$RelativePath
+    )
+
+    $baseDirectory = Split-Path -Parent $BaseFile
+    $combined = Join-Path $baseDirectory $RelativePath
+    $resolved = [System.IO.Path]::GetFullPath($combined)
+    return $resolved
+}
+
+function To-RepoRelativePath {
+    param([string]$AbsolutePath)
+
+    $repoUri = New-Object System.Uri(($repoRoot.TrimEnd('\') + '\'))
+    $fileUri = New-Object System.Uri($AbsolutePath)
+    $relativeUri = $repoUri.MakeRelativeUri($fileUri)
+    return [System.Uri]::UnescapeDataString($relativeUri.ToString())
+}
+
+$ownershipRows = Parse-OwnershipTable
+$ownershipByDoc = @{}
+foreach ($row in $ownershipRows) {
+    if ($ownershipByDoc.ContainsKey($row.Doc)) {
+        Fail "Duplicate doc in AGENTS.md ownership table: $($row.Doc)"
+    }
+    $ownershipByDoc[$row.Doc] = $row
+}
+
+$docFiles = Get-ChildItem $docsRoot -Filter *.md | ForEach-Object { "docs/agent/$($_.Name)" }
+foreach ($doc in $docFiles) {
+    if (-not $ownershipByDoc.ContainsKey($doc)) {
+        Fail "Doc missing from AGENTS.md ownership table: $doc"
+    }
+}
+
+$skillFiles = Get-ChildItem $skillsRoot -Recurse -Filter SKILL.md |
+    Where-Object { $_.Directory.Name -like "langoose-*" }
+
+$primaryOwners = @{}
+foreach ($skillFile in $skillFiles) {
+    $skillName = $skillFile.Directory.Name
+    $primaryDoc = Get-PrimaryDoc -SkillPath $skillFile.FullName
+
+    $resolvedPrimaryDoc = Resolve-RepoRelativeFromFile -BaseFile $skillFile.FullName -RelativePath $primaryDoc
+    if (-not (Test-Path $resolvedPrimaryDoc)) {
+        Fail "$skillName primary doc does not exist: $primaryDoc"
+    }
+
+    $repoRelativePrimaryDoc = To-RepoRelativePath -AbsolutePath $resolvedPrimaryDoc
+
+    if ($primaryOwners.ContainsKey($repoRelativePrimaryDoc)) {
+        $existingOwner = $primaryOwners[$repoRelativePrimaryDoc]
+        $routerPair = @($existingOwner, $skillName) -contains "langoose-dev"
+        if (-not $routerPair) {
+            Fail "Primary doc '$repoRelativePrimaryDoc' is owned by multiple skills: $existingOwner, $skillName"
+        }
+    }
+
+    if ($skillName -ne "langoose-dev") {
+        $primaryOwners[$repoRelativePrimaryDoc] = $skillName
+    }
+
+    if ($skillName -ne "langoose-dev") {
+        $expected = $ownershipByDoc[$repoRelativePrimaryDoc]
+        if (-not $expected) {
+            Fail "$skillName primary doc is not listed in AGENTS.md ownership table: $repoRelativePrimaryDoc"
+        }
+
+        if ($expected.Owner -ne $skillName) {
+            Fail "$skillName primary doc mismatch. AGENTS.md says '$($expected.Owner)' owns $repoRelativePrimaryDoc."
+        }
+    }
+}
+
+foreach ($row in $ownershipRows) {
+    if ($row.Owner -eq "doc-only") {
+        continue
+    }
+
+    if (-not $primaryOwners.ContainsKey($row.Doc)) {
+        Fail "Owned doc has no matching skill primary doc: $($row.Doc) -> $($row.Owner)"
+    }
+}
+
+$referenceFiles = Get-ChildItem $skillsRoot -Recurse -File |
+    Where-Object { $_.FullName -match '[\\/]+references[\\/]' }
+
+if ($referenceFiles.Count -gt 0) {
+    $paths = $referenceFiles | ForEach-Object { $_.FullName.Replace($repoRoot + "\", "") }
+    Fail "Reference files are no longer expected. Remove: $($paths -join ', ')"
+}
+
+Write-Output "Skill/doc ownership map is valid."

--- a/scripts/validate-skill-doc-map.sh
+++ b/scripts/validate-skill-doc-map.sh
@@ -71,11 +71,7 @@ done
 declare -A primary_owner_by_doc
 while IFS= read -r skill_file; do
   skill_dir=$(basename "$(dirname "${skill_file}")")
-  primary_doc=$(awk '
-    /^## Primary Doc$/ { in_primary=1; next }
-    /^## / && in_primary { exit }
-    in_primary && match($0, /\]\(([^)]+)\)/, m) { print m[1] }
-  ' "${skill_file}")
+  primary_doc=$(sed -n '/^## Primary Doc$/,/^## /{ /\](/{s/.*](\([^)]*\)).*/\1/p;}; }' "${skill_file}" | head -1)
 
   [[ -n "${primary_doc}" ]] || fail "${skill_file} is missing a primary doc."
   resolved_primary_doc=$(resolve_from_file "${skill_file}" "${primary_doc}")

--- a/scripts/validate-skill-doc-map.sh
+++ b/scripts/validate-skill-doc-map.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+agents_path="AGENTS.md"
+skills_root=".codex/skills"
+docs_root="docs/agent"
+
+fail() {
+  echo "$1" >&2
+  exit 2
+}
+
+resolve_from_file() {
+  local base_file="$1"
+  local relative_path="$2"
+  python - <<'PY' "$base_file" "$relative_path"
+import os, sys
+base_file = sys.argv[1]
+relative_path = sys.argv[2]
+print(os.path.abspath(os.path.join(os.path.dirname(base_file), relative_path)))
+PY
+}
+
+to_repo_relative() {
+  local absolute_path="$1"
+  python - <<'PY' "$absolute_path"
+import os, sys
+absolute_path = os.path.abspath(sys.argv[1])
+repo_root = os.path.abspath(".")
+print(os.path.relpath(absolute_path, repo_root).replace("\\", "/"))
+PY
+}
+
+mapfile -t doc_files < <(find "${docs_root}" -maxdepth 1 -type f -name '*.md' -printf '%P\n' | sort)
+
+ownership_section=$(awk '
+  /^## Skill Mapping$/ { in_section=1; next }
+  /^## / && in_section { exit }
+  in_section { print }
+' "${agents_path}")
+
+[ -n "${ownership_section}" ] || fail "AGENTS.md is missing the '## Skill Mapping' section."
+
+declare -A owner_by_doc
+while IFS= read -r line; do
+  [[ "${line}" == "| Doc | Owner | Notes |" ]] && continue
+  [[ "${line}" =~ ^\|[-\ \|]+\|$ ]] && continue
+  [[ "${line}" != \|* ]] && continue
+
+  trimmed="${line#|}"
+  trimmed="${trimmed%|}"
+  IFS='|' read -r raw_doc raw_owner raw_notes <<< "${trimmed}"
+  doc=$(echo "${raw_doc}" | xargs)
+  owner=$(echo "${raw_owner}" | xargs)
+  notes=$(echo "${raw_notes}" | xargs)
+  doc="${doc//\`/}"
+  owner="${owner//\`/}"
+
+  [[ -n "${doc}" ]] || continue
+  [[ -z "${owner_by_doc[$doc]:-}" ]] || fail "Duplicate doc in AGENTS.md ownership table: ${doc}"
+  owner_by_doc["${doc}"]="${owner}|${notes}"
+done <<< "${ownership_section}"
+
+for doc_file in "${doc_files[@]}"; do
+  doc="docs/agent/${doc_file}"
+  [[ -n "${owner_by_doc[$doc]:-}" ]] || fail "Doc missing from AGENTS.md ownership table: ${doc}"
+done
+
+declare -A primary_owner_by_doc
+while IFS= read -r skill_file; do
+  skill_dir=$(basename "$(dirname "${skill_file}")")
+  primary_doc=$(awk '
+    /^## Primary Doc$/ { in_primary=1; next }
+    /^## / && in_primary { exit }
+    in_primary && match($0, /\]\(([^)]+)\)/, m) { print m[1] }
+  ' "${skill_file}")
+
+  [[ -n "${primary_doc}" ]] || fail "${skill_file} is missing a primary doc."
+  resolved_primary_doc=$(resolve_from_file "${skill_file}" "${primary_doc}")
+  [[ -f "${resolved_primary_doc}" ]] || fail "${skill_dir} primary doc does not exist: ${primary_doc}"
+  repo_relative_primary_doc=$(to_repo_relative "${resolved_primary_doc}")
+  if [[ -n "${primary_owner_by_doc[$repo_relative_primary_doc]:-}" ]]; then
+    existing_owner="${primary_owner_by_doc[$repo_relative_primary_doc]}"
+    if [[ "${existing_owner}" != "langoose-dev" && "${skill_dir}" != "langoose-dev" ]]; then
+      fail "Primary doc '${repo_relative_primary_doc}' is owned by multiple skills: ${existing_owner}, ${skill_dir}"
+    fi
+  fi
+
+  if [[ "${skill_dir}" != "langoose-dev" ]]; then
+    primary_owner_by_doc["${repo_relative_primary_doc}"]="${skill_dir}"
+  fi
+
+  if [[ "${skill_dir}" != "langoose-dev" ]]; then
+    entry="${owner_by_doc[$repo_relative_primary_doc]:-}"
+    [[ -n "${entry}" ]] || fail "${skill_dir} primary doc is not listed in AGENTS.md ownership table: ${repo_relative_primary_doc}"
+    expected_owner="${entry%%|*}"
+    [[ "${expected_owner}" == "${skill_dir}" ]] || fail "${skill_dir} primary doc mismatch. AGENTS.md says '${expected_owner}' owns ${repo_relative_primary_doc}."
+  fi
+done < <(find "${skills_root}" -mindepth 2 -maxdepth 2 -name 'SKILL.md' | sort)
+
+for doc in "${!owner_by_doc[@]}"; do
+  owner_and_notes="${owner_by_doc[$doc]}"
+  owner="${owner_and_notes%%|*}"
+  if [[ "${owner}" == "doc-only" ]]; then
+    continue
+  fi
+
+  [[ -n "${primary_owner_by_doc[$doc]:-}" ]] || fail "Owned doc has no matching skill primary doc: ${doc} -> ${owner}"
+done
+
+mapfile -t reference_files < <(find "${skills_root}" -type f -path '*/references/*')
+if [[ "${#reference_files[@]}" -gt 0 ]]; then
+  fail "Reference files are no longer expected. Remove: ${reference_files[*]}"
+fi
+
+echo "Skill/doc ownership map is valid."


### PR DESCRIPTION
## Summary

- Add difficulty badge to study cards and enrichment status pill styling (pending/enriched/failed) to dictionary rows
- Reorganize agent docs into focused, load-on-demand structure: split workflows into workflows/git-conventions/quality-gates, create backend-conventions.md, consolidate response shapes into api-contracts.md, slim CLAUDE.md to an index
- Fix sync-rules.sh boundary marker to preserve Skill Mapping section during sync
- Add Conventional Commits and branch naming conventions to git-conventions.md

## Test plan

- [ ] `npm run build` passes in apps/web
- [ ] Dictionary rows show colored pills for pending (orange), enriched (green), failed (red)
- [ ] Study cards show difficulty label when present
- [ ] `scripts/sync-rules.sh audit` passes
- [ ] `scripts/validate-skill-doc-map.sh` passes
- [ ] All doc links in CLAUDE.md and AGENTS.md resolve to existing files

Closes #72