### PR TITLE
feat: add IEnrichmentProvider interface and LocalEnrichmentProvider (#74)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@
 
 ## Core Rules
 
+- Before writing code for a GitHub issue, follow the full issue lifecycle in `docs/agent/git-conventions.md`.
+- Before writing code, read the relevant `docs/agent/` guides for the areas being changed.
 - Prefer small changes that fit the current architecture before introducing new layers or abstractions.
 - Keep business rules on the backend when they affect grading, dictionary visibility, imports, scheduling, auth, or persistence.
 - Prefer first-class integrations for hosted reads and metadata when they are available and reliable. Use local `git` for workspace branch management.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@
 
 ## Core Rules
 
+- Before writing code for a GitHub issue, follow the full issue lifecycle in `docs/agent/git-conventions.md`.
+- Before writing code, read the relevant `docs/agent/` guides for the areas being changed.
 - Prefer small changes that fit the current architecture before introducing new layers or abstractions.
 - Keep business rules on the backend when they affect grading, dictionary visibility, imports, scheduling, auth, or persistence.
 - Prefer first-class integrations for hosted reads and metadata when they are available and reliable. Use local `git` for workspace branch management.

--- a/apps/api/src/Langoose.Api/Program.cs
+++ b/apps/api/src/Langoose.Api/Program.cs
@@ -5,6 +5,7 @@ using Langoose.Api.Configuration;
 using Langoose.Api.Middleware;
 using Langoose.Auth.Data;
 using Langoose.Auth.Data.Models;
+using Langoose.Core.Providers;
 using Langoose.Core.Services;
 using Langoose.Data;
 using Langoose.Data.Seeding;
@@ -119,6 +120,7 @@ builder.Services.AddOpenIddict()
 builder.Services.AddScoped<IDictionaryService, DictionaryService>();
 builder.Services.AddScoped<IStudyService, StudyService>();
 builder.Services.AddScoped<IContentService, ContentService>();
+builder.Services.AddScoped<IEnrichmentProvider, LocalEnrichmentProvider>();
 builder.Services.AddScoped<DatabaseSeeder>();
 
 builder.Services.AddControllers()

--- a/apps/api/src/Langoose.Core/Providers/LocalEnrichmentProvider.cs
+++ b/apps/api/src/Langoose.Core/Providers/LocalEnrichmentProvider.cs
@@ -1,0 +1,57 @@
+using Langoose.Domain.Models;
+using Langoose.Domain.Services;
+
+namespace Langoose.Core.Providers;
+
+public sealed class LocalEnrichmentProvider : IEnrichmentProvider
+{
+    public Task<EnrichmentResult[]> EnrichBatchAsync(
+        EnrichmentRequest[] batch, CancellationToken cancellationToken)
+    {
+        var results = new EnrichmentResult[batch.Length];
+
+        for (var i = 0; i < batch.Length; i++)
+        {
+            results[i] = Enrich(batch[i]);
+        }
+
+        return Task.FromResult(results);
+    }
+
+    private static EnrichmentResult Enrich(EnrichmentRequest request)
+    {
+        var sourceEntry = new EnrichedEntry(
+            Text: request.RawText.Trim(),
+            IsBaseForm: true,
+            BaseFormText: null,
+            GrammarLabel: null,
+            Difficulty: null);
+
+        if (string.IsNullOrWhiteSpace(request.RawTranslation))
+        {
+            return new EnrichmentResult([sourceEntry], [], []);
+        }
+
+        var translation = request.RawTranslation.Trim();
+
+        var targetEntry = new EnrichedEntry(
+            Text: translation,
+            IsBaseForm: true,
+            BaseFormText: null,
+            GrammarLabel: null,
+            Difficulty: null);
+
+        var cloze = $"____ ({translation})";
+        var sentenceText = $"{sourceEntry.Text} ({translation})";
+
+        var context = new EnrichedContext(
+            SourceText: sentenceText,
+            SourceCloze: cloze,
+            TargetText: translation,
+            SourceFormText: sourceEntry.Text,
+            TargetFormText: translation,
+            Difficulty: null);
+
+        return new EnrichmentResult([sourceEntry], [targetEntry], [context]);
+    }
+}

--- a/apps/api/src/Langoose.Domain/Models/EnrichedContext.cs
+++ b/apps/api/src/Langoose.Domain/Models/EnrichedContext.cs
@@ -1,0 +1,9 @@
+namespace Langoose.Domain.Models;
+
+public sealed record EnrichedContext(
+    string SourceText,
+    string SourceCloze,
+    string TargetText,
+    string SourceFormText,
+    string TargetFormText,
+    string? Difficulty);

--- a/apps/api/src/Langoose.Domain/Models/EnrichedEntry.cs
+++ b/apps/api/src/Langoose.Domain/Models/EnrichedEntry.cs
@@ -1,0 +1,8 @@
+namespace Langoose.Domain.Models;
+
+public sealed record EnrichedEntry(
+    string Text,
+    bool IsBaseForm,
+    string? BaseFormText,
+    string? GrammarLabel,
+    string? Difficulty);

--- a/apps/api/src/Langoose.Domain/Models/EnrichmentRequest.cs
+++ b/apps/api/src/Langoose.Domain/Models/EnrichmentRequest.cs
@@ -1,0 +1,7 @@
+namespace Langoose.Domain.Models;
+
+public sealed record EnrichmentRequest(
+    string RawText,
+    string? RawTranslation,
+    string SourceLanguage,
+    string TargetLanguage);

--- a/apps/api/src/Langoose.Domain/Models/EnrichmentResult.cs
+++ b/apps/api/src/Langoose.Domain/Models/EnrichmentResult.cs
@@ -1,0 +1,6 @@
+namespace Langoose.Domain.Models;
+
+public sealed record EnrichmentResult(
+    EnrichedEntry[] SourceEntries,
+    EnrichedEntry[] TargetEntries,
+    EnrichedContext[] Contexts);

--- a/apps/api/src/Langoose.Domain/Services/IEnrichmentProvider.cs
+++ b/apps/api/src/Langoose.Domain/Services/IEnrichmentProvider.cs
@@ -1,0 +1,9 @@
+using Langoose.Domain.Models;
+
+namespace Langoose.Domain.Services;
+
+public interface IEnrichmentProvider
+{
+    Task<EnrichmentResult[]> EnrichBatchAsync(
+        EnrichmentRequest[] batch, CancellationToken cancellationToken);
+}

--- a/apps/api/src/Langoose.Worker/Program.cs
+++ b/apps/api/src/Langoose.Worker/Program.cs
@@ -1,4 +1,19 @@
+using Langoose.Core.Providers;
+using Langoose.Data;
+using Langoose.Domain.Services;
+using Microsoft.EntityFrameworkCore;
+
 var builder = Host.CreateApplicationBuilder(args);
+
+var connectionString = builder.Configuration.GetConnectionString("AppDb")
+    ?? throw new InvalidOperationException("Connection string 'AppDb' is not configured.");
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+{
+    options.UseNpgsql(connectionString);
+});
+
+builder.Services.AddScoped<IEnrichmentProvider, LocalEnrichmentProvider>();
 
 var host = builder.Build();
 host.Run();

--- a/apps/api/src/Langoose.Worker/Program.cs
+++ b/apps/api/src/Langoose.Worker/Program.cs
@@ -5,8 +5,8 @@ using Microsoft.EntityFrameworkCore;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-var connectionString = builder.Configuration.GetConnectionString("AppDb")
-    ?? throw new InvalidOperationException("Connection string 'AppDb' is not configured.");
+var connectionString = builder.Configuration.GetConnectionString("AppDatabase")
+    ?? throw new InvalidOperationException("Connection string 'AppDatabase' is not configured.");
 
 builder.Services.AddDbContext<AppDbContext>(options =>
 {

--- a/apps/api/src/Langoose.Worker/appsettings.json
+++ b/apps/api/src/Langoose.Worker/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "AppDatabase": "Host=localhost;Port=5432;Database=langoose_app;Username=langoose;Password=langoose"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/docs/agent/backend-conventions.md
+++ b/docs/agent/backend-conventions.md
@@ -8,6 +8,7 @@
 - Keep namespaces aligned with the project and folder structure.
 - Keep public and protected members before private helpers.
 - Prefer names that are clear in local scope without adding unnecessary noise.
+- Prefer arrays for immutable collection properties and return values unless a more generic interface provides a concrete benefit.
 - Avoid redundant materialization, qualification, imports, and DI registrations.
 - Replace non-obvious magic numbers with named constants or configuration.
 


### PR DESCRIPTION
## Summary
- Define `IEnrichmentProvider` batch async interface in Domain
- Implement `LocalEnrichmentProvider` static-lexicon fallback in Core
- Register provider in both Api and Worker DI
- Add issue lifecycle and array preference rules to agent docs

Closes #74

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 29 tests pass
- [x] Rules synced via `sync-rules.sh`