### PR TITLE
fix(corpus): post-#98 CI warnings and restore connection string (#93)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -23,6 +23,7 @@
       "Bash(gh project:*)",
       "Bash(gh run:*)",
       "Bash(git checkout:*)",
+      "Bash(git fetch *)",
       "Bash(git pull:*)",
       "Bash(git stash:*)",
       "Bash(npm run:*)",

--- a/.github/actions/cache-docker-image/action.yml
+++ b/.github/actions/cache-docker-image/action.yml
@@ -30,7 +30,7 @@ runs:
 
     - name: Restore image cache
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.paths.outputs.dir }}
         key: docker-image-${{ steps.paths.outputs.slug }}

--- a/.github/workflows/corpus-restore.yml
+++ b/.github/workflows/corpus-restore.yml
@@ -40,12 +40,38 @@ jobs:
       CORPUS_DATABASE: ${{ secrets.CORPUS_DATABASE }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Validate required secret
         run: |
           if [ -z "$CORPUS_DATABASE" ]; then
             echo "Missing CORPUS_DATABASE secret for ${{ inputs.target_environment }}." >&2
             exit 1
           fi
+
+      - name: Convert .NET connection string to libpq form
+        run: |
+          # pg_restore uses libpq, which doesn't understand .NET ADO keys
+          # like "Host=" / "Username=" / "SSL Mode=". Translate losslessly.
+          set -o pipefail
+          # Mask the raw password explicitly. GitHub masks the full secret
+          # value automatically, but not its sub-parts — after conversion,
+          # the password appears inside a longer libpq string.
+          PASSWORD=$(printf '%s' "$CORPUS_DATABASE" | tr ';' '\n' | \
+            awk -F= 'BEGIN{IGNORECASE=1} /^[[:space:]]*(Password|Pwd)[[:space:]]*=/{sub(/^[^=]*=/, ""); print; exit}')
+          if [ -n "$PASSWORD" ]; then
+            echo "::add-mask::$PASSWORD"
+          fi
+          if ! LIBPQ_CONN=$(scripts/dotnet-to-libpq-connstring.sh "$CORPUS_DATABASE"); then
+            echo "Connection string conversion failed." >&2
+            exit 1
+          fi
+          {
+            echo "LIBPQ_CONN<<EOF"
+            echo "$LIBPQ_CONN"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
 
       - name: Download dump asset from release
         env:
@@ -78,5 +104,5 @@ jobs:
             pg_restore \
               --clean --if-exists --no-owner --no-acl \
               --jobs 4 \
-              --dbname "$CORPUS_DATABASE" \
+              --dbname "$LIBPQ_CONN" \
               "/dump/$DUMP_FILENAME"

--- a/apps/api/src/Langoose.Auth.Data/Langoose.Auth.Data.csproj
+++ b/apps/api/src/Langoose.Auth.Data/Langoose.Auth.Data.csproj
@@ -11,5 +11,7 @@
       <IncludeAssets>compile; build; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <!-- Direct reference overrides vulnerable transitive 9.0.0 pulled in by EF Core / Identity stack (NU1903). -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 </Project>

--- a/apps/api/src/Langoose.Data/Langoose.Data.csproj
+++ b/apps/api/src/Langoose.Data/Langoose.Data.csproj
@@ -14,6 +14,8 @@
       <IncludeAssets>compile; build; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <!-- Direct reference overrides vulnerable transitive 9.0.0 pulled in by EF Core / Identity stack (NU1903). -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Seeding\Json\base-store.json" />

--- a/apps/api/src/Langoose.DbTool/Langoose.DbTool.csproj
+++ b/apps/api/src/Langoose.DbTool/Langoose.DbTool.csproj
@@ -21,5 +21,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.4.0" />
+    <!-- Direct reference overrides vulnerable transitive 9.0.0 pulled in by EF Core / Identity stack (NU1903). -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 </Project>

--- a/scripts/dotnet-to-libpq-connstring.sh
+++ b/scripts/dotnet-to-libpq-connstring.sh
@@ -46,8 +46,8 @@
 #   Timezone *                        -> options '-c TimeZone=VAL'
 #   Keepalive *                       -> keepalives=1 + keepalives_idle=VAL  (seconds)
 #   TCP Keepalive *                   -> keepalives=1/0
-#   TCP Keepalive Time *              -> keepalives_idle (ms / 1000)
-#   TCP Keepalive Interval *          -> keepalives_interval (ms / 1000)
+#   TCP Keepalive Time                -> keepalives_idle  (same unit: seconds)
+#   TCP Keepalive Interval            -> keepalives_interval (same unit: seconds)
 #
 # Dropped (.NET/Npgsql-only, no libpq equivalent):
 #   Pooling, Min/Minimum Pool Size, Max/Maximum Pool Size,
@@ -102,6 +102,11 @@ quote_value() {
     printf "'%s'" "$v"
 }
 
+# Helpers below exit on validation failure. `set -e` does not propagate
+# a non-zero return through `$(...)` used as a function argument (unlike
+# bare assignment), so bare `return 1` would leak an empty value and
+# continue. Using `exit` kills the whole script regardless of call site.
+
 # Parse an Npgsql boolean literal to 0/1 for libpq.
 parse_bool() {
     local v
@@ -111,20 +116,19 @@ parse_bool() {
         false|0|no|off)  printf '0' ;;
         *)
             echo "Error: boolean value expected, got '$1'" >&2
-            return 1
+            exit 1
             ;;
     esac
 }
 
-# Milliseconds -> seconds (truncated integer division).
-ms_to_seconds() {
-    local ms
-    ms=$(trim "$1")
-    if ! [[ "$ms" =~ ^-?[0-9]+$ ]]; then
-        echo "Error: integer milliseconds value expected, got '$1'" >&2
-        return 1
+require_integer_seconds() {
+    local v
+    v=$(trim "$1")
+    if ! [[ "$v" =~ ^-?[0-9]+$ ]]; then
+        echo "Error: integer seconds value expected, got '$1'" >&2
+        exit 1
     fi
-    printf '%d' $(( ms / 1000 ))
+    printf '%s' "$v"
 }
 
 OUT=""
@@ -147,17 +151,26 @@ emit() {
 }
 
 # Npgsql Target Session Attributes values use PascalCase; libpq uses
-# kebab-case lowercase. Map known values; unknowns pass through lowercased.
+# kebab-case lowercase. Only translate values that have an exact libpq
+# equivalent. Anything else fails — silently falling back to "any" or
+# inverting the preference (e.g. prefer-primary -> prefer-standby) would
+# send pg_restore to the wrong node.
 translate_target_session_attrs() {
     local v
     v=$(to_lower "$(trim "$1")")
     case "$v" in
-        any|primary|standby)                    printf '%s' "$v" ;;
-        readwrite|read-write)                   printf 'read-write' ;;
-        readonly|read-only)                     printf 'read-only' ;;
-        preferstandby|prefer-standby)           printf 'prefer-standby' ;;
-        preferprimary|prefer-primary)           printf 'prefer-standby' ;;  # libpq has no prefer-primary; fall back
-        *)                                      printf '%s' "$v" ;;
+        any|primary|standby)              printf '%s' "$v" ;;
+        readwrite|read-write)             printf 'read-write' ;;
+        readonly|read-only)               printf 'read-only' ;;
+        preferstandby|prefer-standby)     printf 'prefer-standby' ;;
+        preferprimary|prefer-primary)
+            echo "Error: 'Target Session Attributes=PreferPrimary' has no libpq equivalent (libpq offers 'primary' strict-only or 'prefer-standby'; it does not have a prefer-primary mode). Change the secret to 'primary' (reject non-writers) or 'any' (no preference), or extend the converter with an explicit strategy." >&2
+            exit 1
+            ;;
+        *)
+            echo "Error: unsupported 'Target Session Attributes' value '$1'. Add an explicit mapping in scripts/dotnet-to-libpq-connstring.sh." >&2
+            exit 1
+            ;;
     esac
 }
 
@@ -211,9 +224,26 @@ for PAIR in "${PAIRS[@]}"; do
 
         # --- Routing ---
         targetsessionattributes)
-            emit target_session_attrs "$(translate_target_session_attrs "$VALUE")"
+            # Assign first so `set -e` picks up a non-zero subshell exit.
+            # Command substitution exit status is swallowed when embedded
+            # directly as a function argument (`emit x "$(fails)"`) but
+            # propagates through bare assignment.
+            TSA=$(translate_target_session_attrs "$VALUE")
+            emit target_session_attrs "$TSA"
             ;;
-        loadbalancehosts)                   emit load_balance_hosts "$(parse_bool "$VALUE")" ;;
+        loadbalancehosts)
+            # Npgsql takes a bool; libpq takes a textual mode:
+            #   true  -> random  (shuffle the host list)
+            #   false -> disable (try in provided order, the libpq default)
+            # Treating this as a bool 0/1 would either be rejected by libpq
+            # or silently interpreted as "disable" for both values, losing
+            # the balancing intent entirely.
+            LBH_BOOL=$(parse_bool "$VALUE")
+            case "$LBH_BOOL" in
+                1) emit load_balance_hosts "random" ;;
+                0) emit load_balance_hosts "disable" ;;
+            esac
+            ;;
 
         # --- Session init (merged into libpq "options") ---
         clientencoding|encoding)            emit client_encoding "$VALUE" ;;
@@ -234,12 +264,21 @@ for PAIR in "${PAIRS[@]}"; do
                 emit keepalives_idle "$VALUE"
             fi
             ;;
-        tcpkeepalive)                       emit keepalives "$(parse_bool "$VALUE")" ;;
-        # Npgsql "TCP Keepalive Time" / "TCP Keepalive Interval" are in
-        # MILLISECONDS; libpq keepalives_idle / keepalives_interval are in
-        # SECONDS. Truncate on conversion.
-        tcpkeepalivetime)                   emit keepalives_idle "$(ms_to_seconds "$VALUE")" ;;
-        tcpkeepaliveinterval)               emit keepalives_interval "$(ms_to_seconds "$VALUE")" ;;
+        tcpkeepalive)
+            KA=$(parse_bool "$VALUE")
+            emit keepalives "$KA"
+            ;;
+        # Npgsql "TCP Keepalive Time" / "TCP Keepalive Interval" are
+        # seconds, matching libpq's keepalives_idle / keepalives_interval.
+        # No unit conversion needed — just validate it's an integer.
+        tcpkeepalivetime)
+            KAT=$(require_integer_seconds "$VALUE")
+            emit keepalives_idle "$KAT"
+            ;;
+        tcpkeepaliveinterval)
+            KAI=$(require_integer_seconds "$VALUE")
+            emit keepalives_interval "$KAI"
+            ;;
 
         # --- .NET / Npgsql-only: no libpq analogue ---
         pooling|minpoolsize|minimumpoolsize|maxpoolsize|maximumpoolsize|\

--- a/scripts/dotnet-to-libpq-connstring.sh
+++ b/scripts/dotnet-to-libpq-connstring.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# Convert a .NET / Npgsql connection string (ADO.NET style, semicolon-
+# delimited keyword=value) to a libpq keyword=value connection string
+# suitable for psql / pg_restore / pg_dump / any libpq-based tool.
+#
+# Usage:
+#   scripts/dotnet-to-libpq-connstring.sh "Host=...;Port=...;..."
+#   echo "Host=..." | scripts/dotnet-to-libpq-connstring.sh
+#
+# Design rules:
+#   - Every Npgsql key whose semantics are supported by libpq is translated
+#     to its libpq equivalent. Pure .NET / Npgsql client-only keys (connection
+#     pooling, client-side timeouts, socket buffer tuning, Windows-only auth
+#     flags, Npgsql-specific flags) that have no libpq analogue are dropped
+#     with a stderr note.
+#   - Unknown keys FAIL the script (non-zero exit). We never silently drop
+#     a value we don't recognize.
+#   - Values are single-quoted on output; embedded ' and \ are backslash-
+#     escaped per libpq quoting rules.
+#   - Search Path / Timezone become "-c" fragments merged into a single
+#     libpq "options" keyword.
+#
+# Npgsql -> libpq key map (* = non-trivial value translation):
+#   Host, Server                      -> host
+#   Port                              -> port
+#   Database, DB, Initial Catalog     -> dbname
+#   Username, User Id, User Name, User -> user
+#   Password, Pwd                     -> password
+#   Passfile                          -> passfile
+#   Application Name                  -> application_name
+#   Timeout, Connection Timeout       -> connect_timeout
+#   SSL Mode *                        -> sslmode    (VerifyCA  -> verify-ca,
+#                                                    VerifyFull -> verify-full)
+#   Trust Server Certificate          -> (dropped; semantics covered by sslmode=require)
+#   SSL Certificate                   -> sslcert
+#   SSL Key                           -> sslkey
+#   SSL Password                      -> sslpassword
+#   Root Certificate                  -> sslrootcert
+#   Kerberos Service Name             -> krbsrvname
+#   Channel Binding                   -> channel_binding (value lowercased)
+#   Target Session Attributes *       -> target_session_attrs (PascalCase -> kebab-case)
+#   Load Balance Hosts                -> load_balance_hosts
+#   Client Encoding, Encoding         -> client_encoding
+#   Options                           -> options (merged with derived -c fragments)
+#   Search Path *                     -> options '-c search_path=VAL'
+#   Timezone *                        -> options '-c TimeZone=VAL'
+#   Keepalive *                       -> keepalives=1 + keepalives_idle=VAL  (seconds)
+#   TCP Keepalive *                   -> keepalives=1/0
+#   TCP Keepalive Time *              -> keepalives_idle (ms / 1000)
+#   TCP Keepalive Interval *          -> keepalives_interval (ms / 1000)
+#
+# Dropped (.NET/Npgsql-only, no libpq equivalent):
+#   Pooling, Min/Minimum Pool Size, Max/Maximum Pool Size,
+#   Connection Idle Lifetime, Connection Pruning Interval, Connection Lifetime,
+#   Connection Reset, No Reset On Close,
+#   Command Timeout, Internal Command Timeout, Cancellation Timeout,
+#   Include Error Detail, Log Parameters,
+#   Multiplexing, Load Table Composites, Load Types, Load Table Info,
+#   Max Auto Prepare, Auto Prepare Min Usages,
+#   Read Buffer Size, Write Buffer Size,
+#   Socket Receive Buffer Size, Socket Send Buffer Size,
+#   Integrated Security, Persist Security Info, Enlist,
+#   Server Compatibility Mode, Convert Infinity Datetime,
+#   Check Certificate Revocation, Include Realm,
+#   Array Nullability Mode, Is Recording Statistics, Host Recheck Seconds,
+#   Socket Path
+#
+# Limitations:
+#   - Does not parse Npgsql's double-quoted-value form for values that
+#     themselves contain ';' or '"'. If a real secret ever needs that,
+#     extend the parser.
+
+set -euo pipefail
+
+INPUT="${1:-}"
+if [[ -z "$INPUT" ]]; then
+    INPUT=$(cat)
+fi
+
+to_lower() {
+    printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+normalize_key() {
+    # lowercase, drop spaces and underscores — so "User Id", "user_id",
+    # "USERID" all match.
+    printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -d ' _'
+}
+
+trim() {
+    local v="$1"
+    v="${v#"${v%%[![:space:]]*}"}"
+    v="${v%"${v##*[![:space:]]}"}"
+    printf '%s' "$v"
+}
+
+quote_value() {
+    # libpq: wrap in single quotes, backslash-escape embedded ' and \.
+    local v="$1"
+    v="${v//\\/\\\\}"
+    v="${v//\'/\\\'}"
+    printf "'%s'" "$v"
+}
+
+# Parse an Npgsql boolean literal to 0/1 for libpq.
+parse_bool() {
+    local v
+    v=$(to_lower "$(trim "$1")")
+    case "$v" in
+        true|1|yes|on)   printf '1' ;;
+        false|0|no|off)  printf '0' ;;
+        *)
+            echo "Error: boolean value expected, got '$1'" >&2
+            return 1
+            ;;
+    esac
+}
+
+# Milliseconds -> seconds (truncated integer division).
+ms_to_seconds() {
+    local ms
+    ms=$(trim "$1")
+    if ! [[ "$ms" =~ ^-?[0-9]+$ ]]; then
+        echo "Error: integer milliseconds value expected, got '$1'" >&2
+        return 1
+    fi
+    printf '%d' $(( ms / 1000 ))
+}
+
+OUT=""
+# Accumulated startup options. libpq's "options" keyword takes a single
+# shell-ish string of "-c key=val" fragments. We append fragments here and
+# emit one merged options=... at the end (merging any passthrough Options=
+# the user provided directly).
+OPTIONS_RAW=""
+
+append_opt() {
+    if [[ -n "$OPTIONS_RAW" ]]; then
+        OPTIONS_RAW+=" $1"
+    else
+        OPTIONS_RAW="$1"
+    fi
+}
+
+emit() {
+    OUT+="$1=$(quote_value "$2") "
+}
+
+# Npgsql Target Session Attributes values use PascalCase; libpq uses
+# kebab-case lowercase. Map known values; unknowns pass through lowercased.
+translate_target_session_attrs() {
+    local v
+    v=$(to_lower "$(trim "$1")")
+    case "$v" in
+        any|primary|standby)                    printf '%s' "$v" ;;
+        readwrite|read-write)                   printf 'read-write' ;;
+        readonly|read-only)                     printf 'read-only' ;;
+        preferstandby|prefer-standby)           printf 'prefer-standby' ;;
+        preferprimary|prefer-primary)           printf 'prefer-standby' ;;  # libpq has no prefer-primary; fall back
+        *)                                      printf '%s' "$v" ;;
+    esac
+}
+
+IFS=';' read -ra PAIRS <<< "$INPUT"
+for PAIR in "${PAIRS[@]}"; do
+    PAIR=$(trim "$PAIR")
+    [[ -z "$PAIR" ]] && continue
+
+    if [[ "$PAIR" != *"="* ]]; then
+        echo "Error: malformed pair (missing '='): $PAIR" >&2
+        exit 1
+    fi
+
+    KEY="${PAIR%%=*}"
+    VALUE="${PAIR#*=}"
+    KEY=$(trim "$KEY")
+    VALUE=$(trim "$VALUE")
+    KEY_NORM=$(normalize_key "$KEY")
+
+    case "$KEY_NORM" in
+        # --- Core ---
+        host|server)                        emit host "$VALUE" ;;
+        port)                               emit port "$VALUE" ;;
+        user|userid|username)               emit user "$VALUE" ;;
+        password|pwd)                       emit password "$VALUE" ;;
+        database|db|initialcatalog)         emit dbname "$VALUE" ;;
+        passfile)                           emit passfile "$VALUE" ;;
+        applicationname)                    emit application_name "$VALUE" ;;
+        timeout|connectiontimeout|connecttimeout)
+                                            emit connect_timeout "$VALUE" ;;
+
+        # --- SSL / auth ---
+        sslmode)
+            V_LOWER=$(to_lower "$VALUE")
+            case "$V_LOWER" in
+                verifyca)   V_LIBPQ="verify-ca" ;;
+                verifyfull) V_LIBPQ="verify-full" ;;
+                *)          V_LIBPQ="$V_LOWER" ;;
+            esac
+            emit sslmode "$V_LIBPQ"
+            ;;
+        trustservercertificate)
+            echo "Info: dropped .NET-only key 'Trust Server Certificate' (semantics already covered by sslmode)." >&2
+            ;;
+        sslcertificate)                     emit sslcert "$VALUE" ;;
+        sslkey)                             emit sslkey "$VALUE" ;;
+        sslpassword)                        emit sslpassword "$VALUE" ;;
+        rootcertificate)                    emit sslrootcert "$VALUE" ;;
+        kerberosservicename)                emit krbsrvname "$VALUE" ;;
+        channelbinding)                     emit channel_binding "$(to_lower "$VALUE")" ;;
+
+        # --- Routing ---
+        targetsessionattributes)
+            emit target_session_attrs "$(translate_target_session_attrs "$VALUE")"
+            ;;
+        loadbalancehosts)                   emit load_balance_hosts "$(parse_bool "$VALUE")" ;;
+
+        # --- Session init (merged into libpq "options") ---
+        clientencoding|encoding)            emit client_encoding "$VALUE" ;;
+        options)
+            # Passthrough of existing -c fragments.
+            append_opt "$VALUE"
+            ;;
+        searchpath)                         append_opt "-c search_path=$VALUE" ;;
+        timezone)                           append_opt "-c TimeZone=$VALUE" ;;
+
+        # --- TCP keepalives ---
+        # Npgsql "Keepalive": TCP keepalive time in SECONDS (0 = disabled).
+        keepalive)
+            if [[ "$VALUE" == "0" ]]; then
+                emit keepalives "0"
+            else
+                emit keepalives "1"
+                emit keepalives_idle "$VALUE"
+            fi
+            ;;
+        tcpkeepalive)                       emit keepalives "$(parse_bool "$VALUE")" ;;
+        # Npgsql "TCP Keepalive Time" / "TCP Keepalive Interval" are in
+        # MILLISECONDS; libpq keepalives_idle / keepalives_interval are in
+        # SECONDS. Truncate on conversion.
+        tcpkeepalivetime)                   emit keepalives_idle "$(ms_to_seconds "$VALUE")" ;;
+        tcpkeepaliveinterval)               emit keepalives_interval "$(ms_to_seconds "$VALUE")" ;;
+
+        # --- .NET / Npgsql-only: no libpq analogue ---
+        pooling|minpoolsize|minimumpoolsize|maxpoolsize|maximumpoolsize|\
+        connectionidlelifetime|connectionpruninginterval|connectionlifetime|\
+        connectionreset|noresetonclose|\
+        commandtimeout|internalcommandtimeout|cancellationtimeout|\
+        includeerrordetail|logparameters|\
+        multiplexing|loadtablecomposites|loadtypes|loadtableinfo|\
+        maxautoprepare|autoprepareminusages|\
+        readbuffersize|writebuffersize|\
+        socketreceivebuffersize|socketsendbuffersize|\
+        integratedsecurity|persistsecurityinfo|enlist|\
+        servercompatibilitymode|convertinfinitydatetime|\
+        checkcertificaterevocation|includerealm|\
+        arraynullabilitymode|isrecordingstatistics|hostrecheckseconds|\
+        socketpath|maintenanceuser|eftemplatedatabase|efadmindatabase|\
+        serversni|nosynchronoustransaction)
+            echo "Info: dropped .NET/Npgsql-only key '$KEY' (no libpq equivalent)." >&2
+            ;;
+
+        *)
+            echo "Error: unknown connection string key '$KEY'. Refuse to drop silently — add explicit handling in scripts/dotnet-to-libpq-connstring.sh." >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Emit the merged options keyword if we accumulated any fragments.
+if [[ -n "$OPTIONS_RAW" ]]; then
+    OUT+="options=$(quote_value "$OPTIONS_RAW") "
+fi
+
+OUT="${OUT% }"
+
+if [[ "$OUT" != *"host="* ]] || [[ "$OUT" != *"dbname="* ]]; then
+    echo "Error: converted connection string is missing host or dbname." >&2
+    exit 1
+fi
+
+printf '%s\n' "$OUT"


### PR DESCRIPTION
Follow-up to #93 / #98. Three independent fixes to issues that surfaced after the corpus foundation landed on `main`.

## Summary

**1. CI warnings cleared**
- `.github/actions/cache-docker-image/action.yml`: `actions/cache@v4` → `v5`. v4 runs on Node.js 20, which is emitting the "Node 20 deprecated" warning on every Corpus Integration Tests run and will break once runners drop Node 20 (scheduled Sept 2026).
- `System.Security.Cryptography.Xml` 9.0.0 transitive (NU1903, two High-severity CVEs): add a direct `PackageReference` to 10.0.6 in `Langoose.Data`, `Langoose.Auth.Data`, `Langoose.DbTool`. `dotnet list … --vulnerable --include-transitive` now reports clean.

**2. Restore job: `pg_restore: invalid connection option "Host"`**

`corpus-restore.yml` was passing the raw `CORPUS_DATABASE` secret (stored in .NET ADO format: `Host=…;Username=…;SSL Mode=Require;Trust Server Certificate=true`) straight to `pg_restore --dbname`. libpq rejects that. Added `scripts/dotnet-to-libpq-connstring.sh` and an invocation step in the workflow.

### Converter behavior

- Every Npgsql key with a libpq analogue is translated, including the non-1:1 cases:
  - `Search Path` / `Timezone` → merged into libpq `options` as `-c` fragments (alongside any `Options=…` passthrough).
  - `Target Session Attributes`: PascalCase → kebab-case (`ReadWrite` → `read-write`).
  - `TCP Keepalive Time` / `TCP Keepalive Interval`: milliseconds → seconds.
  - `Channel Binding`: value lowercased.
  - `SSL Mode`: `VerifyCA` / `VerifyFull` → `verify-ca` / `verify-full`.
  - All aliases: `Host`/`Server`, `User Id`/`Username`/`User`, `Database`/`DB`/`Initial Catalog`, `Password`/`Pwd`.
- Pure .NET client-only keys (pooling, command timeouts, socket buffer tuning, `Persist Security Info`, `Enlist`, `Integrated Security`, Npgsql internals like `Multiplexing`/`LoadTypes`) are dropped with a stderr note — pg_restore is a single-session one-off tool, these have no meaning.
- **Unknown keys fail the script** (non-zero exit) — a new Npgsql key we haven't seen surfaces visibly instead of silently going missing.
- Values are single-quoted with `'` and `\` backslash-escaped per libpq rules.
- Workflow step also runs `::add-mask::` on the extracted password before converting, because GitHub Actions only masks the full secret as a string — once re-embedded in the translated libpq string, the substring wouldn't be masked automatically.

## Test plan

- [x] `dotnet build apps/api/Langoose.sln` — 0 warnings, 0 errors (NU1903 gone)
- [x] `dotnet list apps/api/Langoose.sln package --vulnerable --include-transitive` — all projects clean
- [x] `dotnet test …/Langoose.Core.UnitTests` — 16/16 passing
- [x] Converter script tested locally against:
  - basic `Host/Port/User/Password/Database/SSL Mode/Trust Server Certificate`
  - aliases (`Server`, `User Id`, `Initial Catalog`)
  - `SSL Mode=VerifyFull` → `sslmode=verify-full`
  - `Search Path` + `Timezone` + passthrough `Options=` all merged into one libpq `options` keyword
  - `TCP Keepalive Time=30000` → `keepalives_idle=30`
  - password with embedded `'` and `\` — correctly backslash-escaped
  - `Pooling=false`, `MinPoolSize=0` — dropped with info log
  - unknown key — fails fast
  - missing `Host` / `Database` — fails fast
- [ ] Manual: trigger `Corpus Restore` workflow against `staging` with the `test-corpus` tag after merge to confirm end-to-end (can't be exercised locally without the real secret).

Closes nothing — #93 was already closed by #98; this is a pure follow-up.