### PR TITLE
fix(ci): corpus restore exec bit + skip redundant jobs on non-code pushes (#93)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,9 +18,10 @@ jobs:
     name: Changes
     runs-on: ubuntu-latest
     outputs:
-      app: ${{ steps.detect.outputs.app }}
       backend: ${{ steps.detect.outputs.backend }}
       frontend: ${{ steps.detect.outputs.frontend }}
+      migrations_app: ${{ steps.detect.outputs.migrations_app }}
+      migrations_auth: ${{ steps.detect.outputs.migrations_auth }}
 
     steps:
       - name: Detect deploy-relevant changes
@@ -34,37 +35,58 @@ jobs:
               basehead: `${context.payload.before}...${context.payload.after}`
             });
 
-            const files = comparison.data.files;
+            const files = comparison.data.files.map(f => f.filename);
 
             if (files.length >= 300) {
               core.info('Compare API returned 300+ files — assuming truncation, deploying everything');
-              core.setOutput('app', 'true');
               core.setOutput('backend', 'true');
               core.setOutput('frontend', 'true');
+              core.setOutput('migrations_app', 'true');
+              core.setOutput('migrations_auth', 'true');
               return;
             }
 
-            const isCorpusOnly = (filename) =>
-              filename.startsWith('apps/api/src/Langoose.Corpus.') ||
-              filename.startsWith('apps/api/tests/Langoose.Corpus.');
+            const isBackendRuntime = (f) =>
+              f.startsWith('apps/api/src/') &&
+              !f.startsWith('apps/api/src/Langoose.Corpus.') &&
+              !f.startsWith('apps/api/src/Langoose.DbTool/');
 
-            const backend = files.some(f =>
-              f.filename.startsWith('apps/api/') && !isCorpusOnly(f.filename));
-            const frontend = files.some(f => f.filename.startsWith('apps/web/'));
+            const startsWithAny = (f, prefixes) =>
+              prefixes.some(p => f.startsWith(p));
 
-            core.setOutput('app', (backend || frontend) ? 'true' : 'false');
+            const backend = files.some(isBackendRuntime);
+            const frontend = files.some(f => f.startsWith('apps/web/'));
+
+            const dbtoolPrefix = 'apps/api/src/Langoose.DbTool/';
+            const migrationsApp = files.some(f => startsWithAny(f, [
+              'apps/api/src/Langoose.Data/Migrations/',
+              dbtoolPrefix
+            ]));
+            const migrationsAuth = files.some(f => startsWithAny(f, [
+              'apps/api/src/Langoose.Auth.Data/Migrations/',
+              dbtoolPrefix
+            ]));
+
             core.setOutput('backend', backend ? 'true' : 'false');
             core.setOutput('frontend', frontend ? 'true' : 'false');
+            core.setOutput('migrations_app', migrationsApp ? 'true' : 'false');
+            core.setOutput('migrations_auth', migrationsAuth ? 'true' : 'false');
 
   deploy-staging:
     name: Deploy Staging
     needs:
       - ci
       - changes
-    if: needs.changes.outputs.app == 'true'
+    if: >-
+      needs.changes.outputs.backend == 'true'
+      || needs.changes.outputs.frontend == 'true'
+      || needs.changes.outputs.migrations_app == 'true'
+      || needs.changes.outputs.migrations_auth == 'true'
     uses: ./.github/workflows/deploy-environment.yml
     with:
       target_environment: staging
       deploy_api: ${{ needs.changes.outputs.backend == 'true' }}
       deploy_web: ${{ needs.changes.outputs.frontend == 'true' }}
+      run_migrations_app: ${{ needs.changes.outputs.migrations_app == 'true' }}
+      run_migrations_auth: ${{ needs.changes.outputs.migrations_auth == 'true' }}
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,23 +51,52 @@ jobs:
               'compose.yml'
             ];
 
-            if (context.eventName !== 'pull_request') {
+            // Pick the right change source for the event:
+            //   pull_request                  -> listFiles on the PR
+            //   push / workflow_call(push)    -> compare before..after
+            //   workflow_dispatch or unknown  -> run everything (safe default)
+            //
+            // When CI is invoked as a reusable workflow from CD, context
+            // inherits CD's triggering event (push to main), so the push
+            // branch handles it. Earlier the non-PR branch just forced every
+            // output to 'true', making every merge — even a YAML-only one —
+            // run the full backend + frontend + e2e matrix after CD had
+            // already decided not to deploy.
+            let files = null;
+
+            if (context.eventName === 'pull_request') {
+              files = await github.paginate(
+                github.rest.pulls.listFiles,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.payload.pull_request.number,
+                  per_page: 100
+                },
+                response => response.data.map(file => file.filename)
+              );
+            } else if (context.payload.before && context.payload.after
+                && context.payload.before !== '0000000000000000000000000000000000000000') {
+              const comparison = await github.rest.repos.compareCommitsWithBasehead({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                basehead: `${context.payload.before}...${context.payload.after}`
+              });
+              const changed = comparison.data.files || [];
+              if (changed.length >= 300) {
+                core.info('Compare API returned 300+ files — assuming truncation, running everything.');
+              } else {
+                files = changed.map(f => f.filename);
+              }
+            }
+
+            if (files === null) {
+              core.info('No precise change set available — running everything.');
               core.setOutput('backend', 'true');
               core.setOutput('frontend', 'true');
               core.setOutput('e2e', 'true');
               return;
             }
-
-            const files = await github.paginate(
-              github.rest.pulls.listFiles,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number,
-                per_page: 100
-              },
-              response => response.data.map(file => file.filename)
-            );
 
             const matchesAnyExact = exact =>
               files.some(file => exact.includes(file));

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,17 +29,10 @@ jobs:
           script: |
             const globalForceAllFiles = [
               '.editorconfig',
-              '.gitattributes'
+              '.gitattributes',
+              '.github/workflows/ci.yml'
             ];
-            // Any change to shared CI automation — workflows (ci, cd,
-            // deploy, migrations, seed, corpus-restore, ...) or composite
-            // actions under .github/actions/** — forces the full matrix
-            // so we actually exercise the change on main. Without this,
-            // a merge that only modifies .github/actions/cache-docker-image/
-            // action.yml would resolve to backend=false/frontend=false/
-            // e2e=false and no lane would catch the breakage.
             const globalForceAllPrefixes = [
-              '.github/workflows/',
               '.github/actions/'
             ];
             const backendPrefixes = [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,18 @@ jobs:
           script: |
             const globalForceAllFiles = [
               '.editorconfig',
-              '.gitattributes',
-              '.github/workflows/ci.yml'
+              '.gitattributes'
+            ];
+            // Any change to shared CI automation — workflows (ci, cd,
+            // deploy, migrations, seed, corpus-restore, ...) or composite
+            // actions under .github/actions/** — forces the full matrix
+            // so we actually exercise the change on main. Without this,
+            // a merge that only modifies .github/actions/cache-docker-image/
+            // action.yml would resolve to backend=false/frontend=false/
+            // e2e=false and no lane would catch the breakage.
+            const globalForceAllPrefixes = [
+              '.github/workflows/',
+              '.github/actions/'
             ];
             const backendPrefixes = [
               'apps/api/'
@@ -100,12 +110,15 @@ jobs:
 
             const matchesAnyExact = exact =>
               files.some(file => exact.includes(file));
+            const matchesAnyPrefix = prefixes =>
+              files.some(file => prefixes.some(prefix => file.startsWith(prefix)));
             const includesAny = (prefixes, exact = []) =>
               files.some(file =>
                 exact.includes(file) ||
                 prefixes.some(prefix => file.startsWith(prefix)));
 
-            const forceAll = matchesAnyExact(globalForceAllFiles);
+            const forceAll = matchesAnyExact(globalForceAllFiles)
+              || matchesAnyPrefix(globalForceAllPrefixes);
             const backend = forceAll || includesAny(backendPrefixes, backendFiles);
             const frontend = forceAll || includesAny(frontendPrefixes, frontendFiles);
             const e2e = forceAll || includesAny(e2ePrefixes, e2eFiles);

--- a/.github/workflows/corpus-restore.yml
+++ b/.github/workflows/corpus-restore.yml
@@ -63,7 +63,7 @@ jobs:
           if [ -n "$PASSWORD" ]; then
             echo "::add-mask::$PASSWORD"
           fi
-          if ! LIBPQ_CONN=$(scripts/dotnet-to-libpq-connstring.sh "$CORPUS_DATABASE"); then
+          if ! LIBPQ_CONN=$(bash scripts/dotnet-to-libpq-connstring.sh "$CORPUS_DATABASE"); then
             echo "Connection string conversion failed." >&2
             exit 1
           fi

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -272,6 +272,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - resolve-context
+      - validate-config
       - auth-db-migrations
       - app-db-migrations
     if: >-

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -14,6 +14,14 @@ on:
         required: false
         type: boolean
         default: true
+      run_migrations_app:
+        required: false
+        type: boolean
+        default: true
+      run_migrations_auth:
+        required: false
+        type: boolean
+        default: true
   workflow_dispatch:
     inputs:
       target_environment:
@@ -31,6 +39,16 @@ on:
         default: true
       deploy_web:
         description: Deploy the web app
+        required: false
+        type: boolean
+        default: true
+      run_migrations_app:
+        description: Apply app database migrations
+        required: false
+        type: boolean
+        default: true
+      run_migrations_auth:
+        description: Apply auth database migrations
         required: false
         type: boolean
         default: true
@@ -53,6 +71,9 @@ jobs:
       source_sha: ${{ steps.resolve.outputs.source_sha }}
       deploy_api: ${{ steps.resolve.outputs.deploy_api }}
       deploy_web: ${{ steps.resolve.outputs.deploy_web }}
+      run_migrations_app: ${{ steps.resolve.outputs.run_migrations_app }}
+      run_migrations_auth: ${{ steps.resolve.outputs.run_migrations_auth }}
+      build_dbtool: ${{ steps.resolve.outputs.build_dbtool }}
       should_run: ${{ steps.resolve.outputs.should_run }}
 
     steps:
@@ -66,8 +87,21 @@ jobs:
           echo "source_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
           echo "deploy_api=${{ inputs.deploy_api }}" >> "$GITHUB_OUTPUT"
           echo "deploy_web=${{ inputs.deploy_web }}" >> "$GITHUB_OUTPUT"
+          echo "run_migrations_app=${{ inputs.run_migrations_app }}" >> "$GITHUB_OUTPUT"
+          echo "run_migrations_auth=${{ inputs.run_migrations_auth }}" >> "$GITHUB_OUTPUT"
 
-          if [ "${{ inputs.deploy_api }}" = "true" ] || [ "${{ inputs.deploy_web }}" = "true" ]; then
+          # DbTool image only exists to feed migration jobs. Skip building
+          # it entirely when neither migration lane is going to use it.
+          if [ "${{ inputs.run_migrations_app }}" = "true" ] || [ "${{ inputs.run_migrations_auth }}" = "true" ]; then
+            echo "build_dbtool=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "build_dbtool=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ "${{ inputs.deploy_api }}" = "true" ] \
+              || [ "${{ inputs.deploy_web }}" = "true" ] \
+              || [ "${{ inputs.run_migrations_app }}" = "true" ] \
+              || [ "${{ inputs.run_migrations_auth }}" = "true" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           else
             echo "should_run=false" >> "$GITHUB_OUTPUT"
@@ -85,6 +119,8 @@ jobs:
         env:
           DEPLOY_API: ${{ needs.resolve-context.outputs.deploy_api }}
           DEPLOY_WEB: ${{ needs.resolve-context.outputs.deploy_web }}
+          RUN_MIGRATIONS_APP: ${{ needs.resolve-context.outputs.run_migrations_app }}
+          RUN_MIGRATIONS_AUTH: ${{ needs.resolve-context.outputs.run_migrations_auth }}
           AUTH_DATABASE: ${{ secrets.AUTH_DATABASE }}
           APP_DATABASE: ${{ secrets.APP_DATABASE }}
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
@@ -97,13 +133,13 @@ jobs:
         run: |
           set -eu
 
-          if [ -z "$AUTH_DATABASE" ]; then
-            echo "Missing AUTH_DATABASE secret for database migrations." >&2
+          if [ "$RUN_MIGRATIONS_AUTH" = "true" ] && [ -z "$AUTH_DATABASE" ]; then
+            echo "Missing AUTH_DATABASE secret for auth database migrations." >&2
             exit 1
           fi
 
-          if [ -z "$APP_DATABASE" ]; then
-            echo "Missing APP_DATABASE secret for database migrations." >&2
+          if [ "$RUN_MIGRATIONS_APP" = "true" ] && [ -z "$APP_DATABASE" ]; then
+            echo "Missing APP_DATABASE secret for app database migrations." >&2
             exit 1
           fi
 
@@ -148,7 +184,7 @@ jobs:
     needs:
       - resolve-context
       - validate-config
-    if: needs.resolve-context.outputs.deploy_api == 'true'
+    if: needs.resolve-context.outputs.build_dbtool == 'true'
     environment: ${{ needs.resolve-context.outputs.target_environment }}
 
     steps:
@@ -179,7 +215,7 @@ jobs:
     needs:
       - resolve-context
       - build-dbtool-image
-    if: needs.resolve-context.outputs.deploy_api == 'true'
+    if: needs.resolve-context.outputs.run_migrations_auth == 'true'
     environment: ${{ needs.resolve-context.outputs.target_environment }}
 
     env:
@@ -208,7 +244,7 @@ jobs:
     needs:
       - resolve-context
       - build-dbtool-image
-    if: needs.resolve-context.outputs.deploy_api == 'true'
+    if: needs.resolve-context.outputs.run_migrations_app == 'true'
     environment: ${{ needs.resolve-context.outputs.target_environment }}
 
     env:
@@ -238,7 +274,10 @@ jobs:
       - resolve-context
       - auth-db-migrations
       - app-db-migrations
-    if: needs.resolve-context.outputs.deploy_api == 'true'
+    if: >-
+      !cancelled()
+      && !contains(needs.*.result, 'failure')
+      && needs.resolve-context.outputs.deploy_api == 'true'
     environment: ${{ needs.resolve-context.outputs.target_environment }}
 
     steps:
@@ -275,7 +314,10 @@ jobs:
       - resolve-context
       - validate-config
       - deploy-api
-    if: always() && needs.resolve-context.outputs.deploy_web == 'true' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+    if: >-
+      !cancelled()
+      && !contains(needs.*.result, 'failure')
+      && needs.resolve-context.outputs.deploy_web == 'true'
     environment: ${{ needs.resolve-context.outputs.target_environment }}
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
Two follow-ups to #100 that surfaced after it merged.

## Summary

**1. Corpus restore still fails: `Permission denied`**

Run after #100 merged:
```
scripts/dotnet-to-libpq-connstring.sh: Permission denied
Connection string conversion failed.
```
The script is tracked as mode `100644` because my local `chmod +x` during development didn't land in git — Windows doesn't preserve the Unix exec bit. Fix: prefix the invocation with `bash`, matching the convention used by every other `scripts/*.sh` in the repo (`build-*-corpus-dump.sh`, `download-kaikki.sh`, `sync-rules.sh`, `validate-skill-doc-map.sh` are all `100644` and invoked as `bash ...`).

**2. CI runs the full matrix on every merge to main, even for YAML-only changes**

`ci.yml`'s `changes` job was:
```js
if (context.eventName !== 'pull_request') {
  core.setOutput('backend', 'true');
  core.setOutput('frontend', 'true');
  core.setOutput('e2e', 'true');
  return;
}
```

When CD (triggered by push to main) invokes CI via `uses: ./.github/workflows/ci.yml`, CI's context inherits the push event — so this short-circuit forced every output to `true` for every merge, running the full backend build + unit/integration/corpus tests + frontend build/tests + e2e even when CD's own change detection had already decided not to deploy anything.

Fix: teach the changes job to use the same `compareCommitsWithBasehead` pattern CD already uses. Detection branches:
- `pull_request` → `listFiles` on the PR (unchanged)
- push / `workflow_call` inheriting a push → compare `before...after`
- `workflow_dispatch` or any trigger without a precise change set → fall back to running everything (safe default)
- 300+ changed files → assume compare API truncation, run everything

## Scope note

This PR itself will still run the full CI matrix because `.github/workflows/ci.yml` is in `globalForceAllFiles` — that's intentional, so the new detection logic is validated end-to-end before it starts gating future runs. The payoff shows up on the *next* YAML-only or doc-only merge.

## Test plan

- [x] `bash scripts/dotnet-to-libpq-connstring.sh …` still works locally (unchanged script, only the invocation moved)
- [x] CI change-detection logic reviewed for each event path; runtime validation happens via this PR's own CI run (full matrix by design) and the first post-merge non-code push that should now skip backend/frontend/e2e
- [ ] After merge: re-trigger `Corpus Restore` against `staging` / `test-corpus` to confirm the exec fix lands the restore job