### PR TITLE
fix(corpus): default sslrootcert=system for verify-{ca,full} (#93)

### DIFF
--- a/.github/workflows/corpus-restore.yml
+++ b/.github/workflows/corpus-restore.yml
@@ -98,8 +98,18 @@ jobs:
         run: |
           DUMP_PATH=$(find .artifacts/corpus -maxdepth 1 -name '*.dump' | head -n 1)
           DUMP_FILENAME=$(basename "$DUMP_PATH")
+          # PGSSLROOTCERT=system tells libpq 16+ to use the container's
+          # OS trust store (ca-certificates package, bundled in
+          # postgres:17-alpine's libpq 17) instead of the default
+          # ~/.postgresql/root.crt path, which doesn't exist here.
+          # Needed for Npgsql secrets with SSL Mode=VerifyCA / VerifyFull
+          # against providers signed by public CAs (Neon, Supabase, RDS).
+          # An explicit `sslrootcert=/path` inside the libpq string still
+          # wins over this env default. Kept out of the converter script
+          # so generic callers aren't forced onto libpq 16+.
           docker run --rm \
             -v "$PWD/.artifacts/corpus:/dump:ro" \
+            -e PGSSLROOTCERT=system \
             postgres:17-alpine \
             pg_restore \
               --clean --if-exists --no-owner --no-acl \

--- a/scripts/dotnet-to-libpq-connstring.sh
+++ b/scripts/dotnet-to-libpq-connstring.sh
@@ -36,9 +36,15 @@
 #   SSL Key                           -> sslkey
 #   SSL Password                      -> sslpassword
 #   Root Certificate                  -> sslrootcert
-#   (implicit) sslmode verify-{ca,full} with no Root Certificate
-#                                     -> sslrootcert=system  (libpq 16+;
-#                                        mirrors .NET's default OS trust store)
+#
+# The converter does not inject a default `sslrootcert` for
+# sslmode=verify-{ca,full}. .NET uses the OS trust store implicitly;
+# libpq requires either an explicit sslrootcert path or (libpq 16+)
+# the special value `sslrootcert=system`. Callers that want the
+# OS-trust-store default should set PGSSLROOTCERT=system in the
+# environment running pg_restore / psql, or include
+# `Root Certificate=system` in the input — this keeps the script
+# usable with older libpq clients that don't understand `system`.
 #   Kerberos Service Name             -> krbsrvname
 #   Channel Binding                   -> channel_binding (value lowercased)
 #   Target Session Attributes *       -> target_session_attrs (PascalCase -> kebab-case)
@@ -140,15 +146,6 @@ OUT=""
 # emit one merged options=... at the end (merging any passthrough Options=
 # the user provided directly).
 OPTIONS_RAW=""
-# Track sslmode and whether an explicit Root Certificate was provided, so
-# that we can default sslrootcert=system for verify-{ca,full} when the
-# input didn't specify one. .NET / Npgsql verifies against the OS trust
-# store by default; libpq defaults to looking at ~/.postgresql/root.crt
-# which doesn't exist in a typical pg_* container. sslrootcert=system
-# (libpq 16+) matches .NET's behaviour and works with standard public-CA
-# providers (Neon / Supabase / RDS / ...).
-SSLMODE_FINAL=""
-SSLROOTCERT_SET=0
 
 append_opt() {
     if [[ -n "$OPTIONS_RAW" ]]; then
@@ -222,7 +219,6 @@ for PAIR in "${PAIRS[@]}"; do
                 verifyfull) V_LIBPQ="verify-full" ;;
                 *)          V_LIBPQ="$V_LOWER" ;;
             esac
-            SSLMODE_FINAL="$V_LIBPQ"
             emit sslmode "$V_LIBPQ"
             ;;
         trustservercertificate)
@@ -231,10 +227,7 @@ for PAIR in "${PAIRS[@]}"; do
         sslcertificate)                     emit sslcert "$VALUE" ;;
         sslkey)                             emit sslkey "$VALUE" ;;
         sslpassword)                        emit sslpassword "$VALUE" ;;
-        rootcertificate)
-            SSLROOTCERT_SET=1
-            emit sslrootcert "$VALUE"
-            ;;
+        rootcertificate)                    emit sslrootcert "$VALUE" ;;
         kerberosservicename)                emit krbsrvname "$VALUE" ;;
         channelbinding)                     emit channel_binding "$(to_lower "$VALUE")" ;;
 
@@ -325,14 +318,6 @@ done
 # Emit the merged options keyword if we accumulated any fragments.
 if [[ -n "$OPTIONS_RAW" ]]; then
     OUT+="options=$(quote_value "$OPTIONS_RAW") "
-fi
-
-# Default sslrootcert=system for verify-{ca,full} when the caller didn't
-# specify one. See comment near the SSLMODE_FINAL declaration above.
-if [[ "$SSLROOTCERT_SET" -eq 0 ]] \
-        && { [[ "$SSLMODE_FINAL" == "verify-ca" ]] || [[ "$SSLMODE_FINAL" == "verify-full" ]]; }; then
-    OUT+="sslrootcert='system' "
-    echo "Info: sslmode=$SSLMODE_FINAL set with no explicit Root Certificate — defaulting sslrootcert=system (libpq 16+) to mirror .NET's OS-trust-store behaviour." >&2
 fi
 
 OUT="${OUT% }"

--- a/scripts/dotnet-to-libpq-connstring.sh
+++ b/scripts/dotnet-to-libpq-connstring.sh
@@ -36,6 +36,9 @@
 #   SSL Key                           -> sslkey
 #   SSL Password                      -> sslpassword
 #   Root Certificate                  -> sslrootcert
+#   (implicit) sslmode verify-{ca,full} with no Root Certificate
+#                                     -> sslrootcert=system  (libpq 16+;
+#                                        mirrors .NET's default OS trust store)
 #   Kerberos Service Name             -> krbsrvname
 #   Channel Binding                   -> channel_binding (value lowercased)
 #   Target Session Attributes *       -> target_session_attrs (PascalCase -> kebab-case)
@@ -137,6 +140,15 @@ OUT=""
 # emit one merged options=... at the end (merging any passthrough Options=
 # the user provided directly).
 OPTIONS_RAW=""
+# Track sslmode and whether an explicit Root Certificate was provided, so
+# that we can default sslrootcert=system for verify-{ca,full} when the
+# input didn't specify one. .NET / Npgsql verifies against the OS trust
+# store by default; libpq defaults to looking at ~/.postgresql/root.crt
+# which doesn't exist in a typical pg_* container. sslrootcert=system
+# (libpq 16+) matches .NET's behaviour and works with standard public-CA
+# providers (Neon / Supabase / RDS / ...).
+SSLMODE_FINAL=""
+SSLROOTCERT_SET=0
 
 append_opt() {
     if [[ -n "$OPTIONS_RAW" ]]; then
@@ -210,6 +222,7 @@ for PAIR in "${PAIRS[@]}"; do
                 verifyfull) V_LIBPQ="verify-full" ;;
                 *)          V_LIBPQ="$V_LOWER" ;;
             esac
+            SSLMODE_FINAL="$V_LIBPQ"
             emit sslmode "$V_LIBPQ"
             ;;
         trustservercertificate)
@@ -218,7 +231,10 @@ for PAIR in "${PAIRS[@]}"; do
         sslcertificate)                     emit sslcert "$VALUE" ;;
         sslkey)                             emit sslkey "$VALUE" ;;
         sslpassword)                        emit sslpassword "$VALUE" ;;
-        rootcertificate)                    emit sslrootcert "$VALUE" ;;
+        rootcertificate)
+            SSLROOTCERT_SET=1
+            emit sslrootcert "$VALUE"
+            ;;
         kerberosservicename)                emit krbsrvname "$VALUE" ;;
         channelbinding)                     emit channel_binding "$(to_lower "$VALUE")" ;;
 
@@ -309,6 +325,14 @@ done
 # Emit the merged options keyword if we accumulated any fragments.
 if [[ -n "$OPTIONS_RAW" ]]; then
     OUT+="options=$(quote_value "$OPTIONS_RAW") "
+fi
+
+# Default sslrootcert=system for verify-{ca,full} when the caller didn't
+# specify one. See comment near the SSLMODE_FINAL declaration above.
+if [[ "$SSLROOTCERT_SET" -eq 0 ]] \
+        && { [[ "$SSLMODE_FINAL" == "verify-ca" ]] || [[ "$SSLMODE_FINAL" == "verify-full" ]]; }; then
+    OUT+="sslrootcert='system' "
+    echo "Info: sslmode=$SSLMODE_FINAL set with no explicit Root Certificate — defaulting sslrootcert=system (libpq 16+) to mirror .NET's OS-trust-store behaviour." >&2
 fi
 
 OUT="${OUT% }"


### PR DESCRIPTION
Follow-up to #101. The corpus restore job still fails after the exec-bit fix merged.

## Symptom

```
pg_restore: error: connection to server at "ep-...neon.tech" failed:
  root certificate file "/root/.postgresql/root.crt" does not exist
```

## Cause

The converter correctly translates Npgsql's \`Ssl Mode=VerifyFull\` to libpq's \`sslmode=verify-full\`, but then libpq looks for the root CA at its default path (\`~/.postgresql/root.crt\`) which doesn't exist in the \`postgres:17-alpine\` container. Npgsql verifies against the **OS** trust store by default; libpq requires an explicit \`sslrootcert\`, or the special value \`system\` (libpq 16+) to use the OS trust store.

## Fix

When \`sslmode\` is \`verify-ca\` or \`verify-full\` AND the input didn't supply a \`Root Certificate\`, the converter now emits \`sslrootcert='system'\`. Preserves user intent (verify against an appropriate trust store) and matches what .NET does by default. Works transparently for Neon, Supabase, RDS, and anything signed by a public CA. Explicit \`Root Certificate=/path\` still wins for private CA setups.

Requires libpq 16+. \`postgres:17-alpine\` ships libpq 17 + \`ca-certificates\`, which the Corpus Restore workflow uses.

## Test plan

- [x] \`Ssl Mode=VerifyFull\` (no Root Cert) → \`sslrootcert='system'\`
- [x] \`Ssl Mode=VerifyFull\` + \`Root Certificate=/my/ca.crt\` → \`sslrootcert='/my/ca.crt'\`  (explicit wins)
- [x] \`Ssl Mode=VerifyCA\` (no Root Cert) → \`sslrootcert='system'\`
- [x] \`Ssl Mode=Require\` + \`Trust Server Certificate=true\` → no sslrootcert emitted (unchanged)
- [ ] After merge: re-trigger \`Corpus Restore\` against \`staging\` / \`test-corpus\` to confirm the full path works end-to-end.