### PR TITLE
feat(corpus): partition wiktionary_entries by lang_code (#97)

### DIFF
--- a/apps/api/src/Langoose.Corpus.Data/Schema/002_wiktionary.sql
+++ b/apps/api/src/Langoose.Corpus.Data/Schema/002_wiktionary.sql
@@ -11,27 +11,138 @@
 -- Wiktionary splits by etymology (e.g. English "lead" = metal + leash,
 -- Russian "замок" = castle + lock), so forcing uniqueness would be lossy.
 -- Rows are never updated — the importer replaces by lang_code.
+--
+-- LIST-partitioned by `lang_code` (#97). Each language gets its own
+-- partition `wiktionary_entries_<lang>` with its own indexes, so a
+-- single-language re-import only rebuilds one partition's GIN index
+-- instead of scanning the whole table. Partitions are created on demand
+-- by the importer through corpus_wiktionary_ensure_partition() — the
+-- parent ships empty with no up-front list of supported languages.
+-- Indexes live on the partitions, not the parent, so the drop-rebuild
+-- during import only touches the partition being loaded. Query authors
+-- must always filter by `lang_code` (documented in
+-- docs/agent/enrichment-guidance.md) so the planner can prune.
 CREATE TABLE IF NOT EXISTS wiktionary_entries (
     lang_code VARCHAR(10) NOT NULL,
     word VARCHAR(300) NOT NULL,
     pos VARCHAR(50) NOT NULL,
     source_version VARCHAR(32) NOT NULL,
     data JSONB NOT NULL
-);
+) PARTITION BY LIST (lang_code);
 
--- Primary lookup: (lang, word, pos) → entry
-CREATE INDEX IF NOT EXISTS ix_wiktionary_entries_lookup
-    ON wiktionary_entries (lang_code, word, pos);
+-- Per-partition DDL helpers. Encapsulating the partition + index naming
+-- convention here (rather than templating it in C#) keeps the index
+-- structure visible alongside the table definition: a future change like
+-- adding a third index lives in one place. The C# importer becomes a
+-- thin caller that passes lang_code as a parameter.
+--
+-- All helpers validate lang_code against the same regex; they're safe
+-- to call directly from psql. format() with %I quotes identifiers and
+-- %L quotes literals, closing the only DDL injection path.
 
--- GIN index on the JSONB column with jsonb_path_ops (smaller, faster for @>
--- containment). Used for runtime lookups like:
---   - "entries where any sense has a translation matching (target_lang, target_text)"
---     data @> '{"senses":[{"translations":[{"code":"ru","word":"книга"}]}]}'::jsonb
---   - "entries whose forms[] contains a given inflected form"
---     data @> '{"forms":[{"form":"бронировал"}]}'::jsonb
--- Pure derivations from the JSONB — no separate form-index table needed at
--- this scale. If the provider ever benchmarks these as too slow, a
--- dedicated form-index table can be materialised as a follow-up step
--- (it's pure derived data, rebuildable without re-importing).
-CREATE INDEX IF NOT EXISTS ix_wiktionary_entries_data
-    ON wiktionary_entries USING GIN (data jsonb_path_ops);
+CREATE OR REPLACE FUNCTION corpus_wiktionary_assert_lang_code(lang_code text)
+    RETURNS void
+    LANGUAGE plpgsql
+    IMMUTABLE
+AS $$
+BEGIN
+    IF lang_code IS NULL OR lang_code !~ '^[a-z][a-z0-9_]*$' THEN
+        RAISE EXCEPTION 'Invalid lang_code %: must match [a-z][a-z0-9_]*. '
+            'lang_code is interpolated into partition/index DDL where parameters '
+            'are not allowed; the regex restricts it to a safe identifier.',
+            COALESCE(quote_literal(lang_code), 'NULL');
+    END IF;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION corpus_wiktionary_ensure_partition(lang_code text)
+    RETURNS void
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM corpus_wiktionary_assert_lang_code(lang_code);
+    EXECUTE format(
+        'CREATE TABLE IF NOT EXISTS %I PARTITION OF wiktionary_entries FOR VALUES IN (%L)',
+        'wiktionary_entries_' || lang_code,
+        lang_code);
+END
+$$;
+
+CREATE OR REPLACE FUNCTION corpus_wiktionary_drop_partition(lang_code text)
+    RETURNS void
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM corpus_wiktionary_assert_lang_code(lang_code);
+    EXECUTE format('DROP TABLE IF EXISTS %I', 'wiktionary_entries_' || lang_code);
+END
+$$;
+
+CREATE OR REPLACE FUNCTION corpus_wiktionary_truncate_partition(lang_code text)
+    RETURNS void
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM corpus_wiktionary_assert_lang_code(lang_code);
+    EXECUTE format('TRUNCATE TABLE %I', 'wiktionary_entries_' || lang_code);
+END
+$$;
+
+CREATE OR REPLACE FUNCTION corpus_wiktionary_drop_partition_indexes(lang_code text)
+    RETURNS void
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    partition_name text;
+BEGIN
+    PERFORM corpus_wiktionary_assert_lang_code(lang_code);
+    partition_name := 'wiktionary_entries_' || lang_code;
+    EXECUTE format('DROP INDEX IF EXISTS %I', 'ix_' || partition_name || '_lookup');
+    EXECUTE format('DROP INDEX IF EXISTS %I', 'ix_' || partition_name || '_data');
+END
+$$;
+
+-- Builds the two indexes that every partition carries. Caller is
+-- expected to bracket the call with `SET LOCAL maintenance_work_mem`
+-- and `SET LOCAL max_parallel_maintenance_workers` for the GIN bulk
+-- build — those settings have no effect when issued inside a function
+-- body (they apply to the function's call frame, not the surrounding
+-- CREATE INDEX), so they have to live at the calling transaction level.
+CREATE OR REPLACE FUNCTION corpus_wiktionary_create_partition_indexes(lang_code text)
+    RETURNS void
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    partition_name text;
+BEGIN
+    PERFORM corpus_wiktionary_assert_lang_code(lang_code);
+    partition_name := 'wiktionary_entries_' || lang_code;
+    EXECUTE format(
+        'CREATE INDEX %I ON %I (lang_code, word, pos)',
+        'ix_' || partition_name || '_lookup',
+        partition_name);
+    EXECUTE format(
+        'CREATE INDEX %I ON %I USING GIN (data jsonb_path_ops)',
+        'ix_' || partition_name || '_data',
+        partition_name);
+END
+$$;
+
+-- Lists every existing wiktionary partition by its lang_code (the
+-- partition-name suffix). Drives reset-wiktionary's bulk drop and
+-- rebuild-indexes' bulk index rebuild.
+CREATE OR REPLACE FUNCTION corpus_wiktionary_list_partition_lang_codes()
+    RETURNS SETOF text
+    LANGUAGE sql
+    STABLE
+AS $$
+    SELECT substring(c.relname FROM length('wiktionary_entries_') + 1)
+    FROM pg_inherits i
+    JOIN pg_class c ON c.oid = i.inhrelid
+    JOIN pg_class p ON p.oid = i.inhparent
+    JOIN pg_namespace ns ON ns.oid = p.relnamespace
+    WHERE p.relname = 'wiktionary_entries'
+      AND ns.nspname = 'public'
+      AND c.relname LIKE 'wiktionary_entries\_%' ESCAPE '\'
+    ORDER BY c.relname
+$$;

--- a/apps/api/src/Langoose.Corpus.DbTool/CorpusInitializer.cs
+++ b/apps/api/src/Langoose.Corpus.DbTool/CorpusInitializer.cs
@@ -5,7 +5,8 @@ namespace Langoose.Corpus.DbTool;
 
 /// <summary>
 /// Applies the corpus schema (embedded SQL files) to a target database in
-/// a single transaction. Each script must be idempotent (uses IF NOT EXISTS).
+/// a single transaction. Each script must be idempotent (uses IF NOT EXISTS
+/// and CREATE OR REPLACE).
 /// </summary>
 public sealed class CorpusInitializer(NpgsqlDataSource dataSource)
 {

--- a/apps/api/src/Langoose.Corpus.DbTool/Importers/WiktionaryImporter.cs
+++ b/apps/api/src/Langoose.Corpus.DbTool/Importers/WiktionaryImporter.cs
@@ -14,6 +14,12 @@ namespace Langoose.Corpus.DbTool.Importers;
 /// corpus database. Streams the input (no full-file load), bulk-loads via
 /// <see cref="NpgsqlBinaryImporter"/>, and replaces any existing rows for
 /// the same language in a single transaction.
+///
+/// Per #97 the table is LIST-partitioned by <c>lang_code</c>: this importer
+/// ensures the per-language partition exists, drops/rebuilds only that
+/// partition's indexes, and TRUNCATEs the partition rather than scanning
+/// the whole table for a per-row DELETE. Other languages' partitions are
+/// untouched.
 /// </summary>
 public sealed class WiktionaryImporter(
     NpgsqlDataSource dataSource,
@@ -37,49 +43,41 @@ public sealed class WiktionaryImporter(
         await using var connection = await dataSource.OpenConnectionAsync(ct);
         await using var transaction = await connection.BeginTransactionAsync(ct);
 
-        // 1. Replace any existing rows for this language. Skipped in bulk
-        //    mode (--defer-indexes) — the caller is expected to have run
-        //    `reset-wiktionary` before the loop, so the table is already
-        //    empty; a per-language DELETE would just scan for nothing.
-        var deleteElapsed = TimeSpan.Zero;
-        long deletedRows = 0;
-        if (!deferIndexes)
-        {
-            var deleteStopwatch = Stopwatch.StartNew();
-            Console.WriteLine($"[{Name}] Clearing existing rows for lang_code={langCode}...");
-            await using (var deleteCommand = connection.CreateCommand())
-            {
-                deleteCommand.Transaction = transaction;
-                deleteCommand.CommandText =
-                    "DELETE FROM wiktionary_entries WHERE lang_code = @lang_code";
-                deleteCommand.Parameters.AddWithValue("lang_code", langCode);
-                // Large-language DELETEs can easily run past the Npgsql
-                // default 30s command timeout. This step is bounded by
-                // user's ctrl-c.
-                deleteCommand.CommandTimeout = 0;
+        // 1. Make sure this language's partition exists. Idempotent — re-imports
+        //    under the same lang_code reuse it. In the bulk (--defer-indexes)
+        //    flow `reset-wiktionary` will have dropped any pre-existing
+        //    partition first, so this is also where partitions come back
+        //    after a reset. Validates lang_code as a safe identifier.
+        Console.WriteLine($"[{Name}] Ensuring partition {WiktionaryIndexMaintenance.PartitionName(langCode)} exists...");
+        await WiktionaryIndexMaintenance.EnsurePartitionAsync(connection, transaction, langCode, ct);
 
-                deletedRows = await deleteCommand.ExecuteNonQueryAsync(ct);
-            }
-            deleteElapsed = deleteStopwatch.Elapsed;
-            Console.WriteLine(
-                $"[{Name}] Cleared {deletedRows:N0} rows in {FormatDuration(deleteElapsed)}");
-        }
-
-        // 2. Drop indexes before COPY so we don't pay per-row GIN maintenance.
-        //    The JSONB GIN index is especially expensive incrementally (~50-100
-        //    path inserts per Wiktionary entry); building it in bulk after
-        //    COPY is typically 10-30× faster. Skipped in bulk mode — the
-        //    `reset-wiktionary` step run before the bulk loop has already
-        //    dropped them, so repeating here would be a no-op.
+        // 2. Drop the partition's indexes before COPY so we don't pay
+        //    per-row GIN maintenance. The JSONB GIN index is especially
+        //    expensive incrementally (~50-100 path inserts per Wiktionary
+        //    entry); building it in bulk after COPY is typically 10-30×
+        //    faster. Skipped in --defer-indexes mode — reset-wiktionary
+        //    drops all partitions before the bulk loop, so the freshly
+        //    created partition has no indexes to drop.
         var dropIndexElapsed = TimeSpan.Zero;
+        var truncateElapsed = TimeSpan.Zero;
         if (!deferIndexes)
         {
-            Console.WriteLine($"[{Name}] Dropping indexes (rebuilt after COPY)...");
+            Console.WriteLine($"[{Name}] Dropping partition indexes (rebuilt after COPY)...");
             dropIndexElapsed = await WiktionaryIndexMaintenance.DropAsync(
-                connection, transaction, ct);
+                connection, transaction, langCode, ct);
+
+            // 3. TRUNCATE the partition. Constant-time replacement for the
+            //    pre-#97 per-row DELETE — TRUNCATE skips the scan and
+            //    reclaims space immediately, and it only affects this
+            //    language's rows.
+            var truncateStopwatch = Stopwatch.StartNew();
+            Console.WriteLine($"[{Name}] Truncating partition for lang_code={langCode}...");
+            await WiktionaryIndexMaintenance.TruncatePartitionAsync(
+                connection, transaction, langCode, ct);
+            truncateElapsed = truncateStopwatch.Elapsed;
         }
 
-        // 3. Optionally load a frequency-ranked allowlist. Used by mini-dump
+        // 4. Optionally load a frequency-ranked allowlist. Used by mini-dump
         //    builds to keep entries representative of everyday vocabulary
         //    instead of taking the first N entries (which Kaikki publishes
         //    in roughly alphabetical order, biased toward `a-`/`ab-`).
@@ -100,7 +98,8 @@ public sealed class WiktionaryImporter(
             }
         }
 
-        // 4. Stream JSONL and bulk-COPY entries.
+        // 5. Stream JSONL and bulk-COPY entries. COPY targets the parent
+        //    table; Postgres routes each row to its partition by lang_code.
         Console.WriteLine($"[{Name}] Streaming {sourcePath}...");
         var copyStopwatch = Stopwatch.StartNew();
         var entriesImported = await CopyEntriesAsync(
@@ -109,16 +108,16 @@ public sealed class WiktionaryImporter(
         Console.WriteLine(
             $"[{Name}] COPY complete: {entriesImported:N0} entries in {FormatDuration(copyElapsed)} ({RateOrDash(entriesImported, copyElapsed)})");
 
-        // 5. Rebuild indexes — unless the caller is running a multi-language
-        //    bulk build and will call `rebuild-indexes` once at the end.
-        //    See #97 for the per-language partition follow-up that would
-        //    localise the rebuild cost when many languages are loaded.
+        // 6. Rebuild the partition's indexes — unless the caller is running
+        //    a multi-language bulk build and will call `rebuild-indexes`
+        //    once at the end. Per-partition rebuild only scans this
+        //    language's rows, which is the whole point of #97.
         TimeSpan buildIndexElapsed = TimeSpan.Zero;
         if (!deferIndexes)
         {
-            Console.WriteLine($"[{Name}] Rebuilding indexes...");
+            Console.WriteLine($"[{Name}] Rebuilding partition indexes...");
             buildIndexElapsed = await WiktionaryIndexMaintenance.CreateAsync(
-                connection, transaction, ct);
+                connection, transaction, langCode, ct);
             Console.WriteLine(
                 $"[{Name}] Indexes rebuilt in {FormatDuration(buildIndexElapsed)}");
         }
@@ -128,7 +127,7 @@ public sealed class WiktionaryImporter(
                 $"[{Name}] Skipping index rebuild (--defer-indexes set). Run `rebuild-indexes` after all languages are imported.");
         }
 
-        // 6. Record provenance.
+        // 7. Record provenance.
         var metadataStopwatch = Stopwatch.StartNew();
         await using (var metadataCommand = connection.CreateCommand())
         {
@@ -146,7 +145,7 @@ public sealed class WiktionaryImporter(
         }
         var metadataElapsed = metadataStopwatch.Elapsed;
 
-        // 7. Commit the transaction.
+        // 8. Commit the transaction.
         var commitStopwatch = Stopwatch.StartNew();
         await transaction.CommitAsync(ct);
         var commitElapsed = commitStopwatch.Elapsed;
@@ -156,8 +155,8 @@ public sealed class WiktionaryImporter(
         Console.WriteLine($"[{Name}] Done in {FormatDuration(totalElapsed)}. Breakdown:");
         if (!deferIndexes)
         {
-            Console.WriteLine($"[{Name}]   delete        {FormatDuration(deleteElapsed),10}");
             Console.WriteLine($"[{Name}]   drop indexes  {FormatDuration(dropIndexElapsed),10}");
+            Console.WriteLine($"[{Name}]   truncate      {FormatDuration(truncateElapsed),10}");
         }
         Console.WriteLine($"[{Name}]   copy          {FormatDuration(copyElapsed),10}");
         if (!deferIndexes)
@@ -211,7 +210,7 @@ public sealed class WiktionaryImporter(
             // truth for the stored column. The source entry's lang_code is
             // validated to match in StreamEntriesAsync, so these are
             // always equal here — writing the constructor value keeps the
-            // DELETE/COPY/metadata triple unambiguously consistent.
+            // partition routing and metadata stamp unambiguously consistent.
             await importer.WriteAsync(langCode, NpgsqlDbType.Varchar, ct);
             await importer.WriteAsync(entry.Data.Word, NpgsqlDbType.Varchar, ct);
             await importer.WriteAsync(entry.Data.Pos, NpgsqlDbType.Varchar, ct);
@@ -327,13 +326,13 @@ public sealed class WiktionaryImporter(
             }
 
             // Fail fast if the source file's declared lang_code doesn't
-            // match the --lang flag. Without this check, the DELETE
-            // (keyed on the constructor's langCode) and the COPY (would
-            // otherwise write the source's lang_code) could disagree —
-            // existing rows of langCode wiped, new rows inserted under a
-            // different code, and metadata stamped under the wrong key.
-            // Transaction rollback in the caller restores pre-import
-            // state cleanly.
+            // match the --lang flag. Without this check, the TRUNCATE
+            // (keyed on the constructor's langCode partition) and the COPY
+            // (would otherwise route the source's lang_code into a
+            // different partition) could disagree — existing rows of
+            // langCode wiped, new rows landing under a different code,
+            // metadata stamped under the wrong key. Transaction rollback
+            // in the caller restores pre-import state cleanly.
             if (!string.Equals(data.LangCode, langCode, StringComparison.Ordinal))
             {
                 throw new InvalidOperationException(

--- a/apps/api/src/Langoose.Corpus.DbTool/Program.cs
+++ b/apps/api/src/Langoose.Corpus.DbTool/Program.cs
@@ -12,11 +12,13 @@ if (args.Length == 0)
         Langoose corpus DbTool. Subcommands:
 
           init                              Apply embedded SQL schema to the corpus database.
-          reset-wiktionary                  Truncate wiktionary_entries and clear all
-                                            source_version_wiktionary_* metadata rows.
-                                            Use at the start of a full bulk build so
-                                            languages removed from the LANGUAGES list
-                                            don't linger in the dump.
+          reset-wiktionary                  Drop every wiktionary_entries_<lang>
+                                            partition (and its indexes) and clear
+                                            all source_version_wiktionary_* metadata
+                                            rows. Use at the start of a full bulk
+                                            build so languages removed from the
+                                            LANGUAGES list don't linger in the dump
+                                            as empty partitions.
           reset-wordfreq                    Truncate wordfreq_rankings and clear all
                                             source_version_wordfreq_* metadata rows.
                                             Wordfreq counterpart of reset-wiktionary.
@@ -48,9 +50,12 @@ if (args.Length == 0)
                                             the `source` column so multiple frequency
                                             sources (wordfreq, SUBTLEX, ...) can
                                             coexist for the same language.
-          rebuild-indexes                   Drop and recreate the wiktionary_entries
-                                            indexes. Idempotent. Typically the final
-                                            step of a bulk multi-language build.
+          rebuild-indexes                   For every wiktionary_entries_<lang>
+                                            partition that exists, drop and
+                                            recreate its two indexes. Idempotent.
+                                            Typically the final step of a bulk
+                                            multi-language build that ran each
+                                            import-wiktionary with --defer-indexes.
         """);
 
     return 1;
@@ -100,35 +105,39 @@ static async Task<int> RunInitAsync(NpgsqlDataSource dataSource)
 static async Task<int> RunResetWiktionaryAsync(NpgsqlDataSource dataSource)
 {
     var stopwatch = Stopwatch.StartNew();
-    Console.WriteLine("Resetting wiktionary data (truncate + clear metadata + drop indexes)...");
+    Console.WriteLine("Resetting wiktionary data (drop all partitions + clear metadata)...");
 
     await using var connection = await dataSource.OpenConnectionAsync();
     await using var transaction = await connection.BeginTransactionAsync();
+
+    // Per #97 wiktionary_entries is LIST-partitioned by lang_code. Dropping
+    // every partition (rather than just truncating the parent) makes the
+    // dump match LANGUAGES exactly — a partition for a language no longer
+    // in LANGUAGES would otherwise linger as an empty partition in the
+    // dump. The importer's `EnsurePartitionAsync` recreates them on demand.
+    var partitions = await WiktionaryIndexMaintenance.ListPartitionLangCodesAsync(
+        connection, transaction, default);
+    foreach (var lang in partitions)
+    {
+        await WiktionaryIndexMaintenance.DropPartitionAsync(
+            connection, transaction, lang, default);
+    }
 
     await using (var command = connection.CreateCommand())
     {
         command.Transaction = transaction;
         command.CommandTimeout = 0;
-        // TRUNCATE avoids the per-row scan cost of a big DELETE and
-        // reclaims space immediately. CASCADE isn't needed — no FKs target
-        // this table.
         command.CommandText = """
-            TRUNCATE TABLE wiktionary_entries;
             DELETE FROM corpus_metadata
                 WHERE key LIKE 'source_version_wiktionary_%';
             """;
         await command.ExecuteNonQueryAsync();
     }
 
-    // Dropping the indexes here (as part of the reset) means subsequent
-    // `import-wiktionary --defer-indexes` calls don't need to repeat the
-    // DROP IF EXISTS dance — they can assume a fresh, unindexed table.
-    // `rebuild-indexes` at the end of the bulk flow recreates them.
-    await WiktionaryIndexMaintenance.DropAsync(connection, transaction, default);
-
     await transaction.CommitAsync();
 
-    Console.WriteLine($"Done in {FormatDuration(stopwatch.Elapsed)}.");
+    Console.WriteLine(
+        $"Done in {FormatDuration(stopwatch.Elapsed)}. Dropped {partitions.Count} partition(s).");
     return 0;
 }
 
@@ -215,16 +224,32 @@ static async Task<int> RunImportWordfreqAsync(NpgsqlDataSource dataSource, strin
 static async Task<int> RunRebuildIndexesAsync(NpgsqlDataSource dataSource)
 {
     var totalStopwatch = Stopwatch.StartNew();
-    Console.WriteLine("Rebuilding wiktionary_entries indexes...");
+    Console.WriteLine("Rebuilding wiktionary_entries partition indexes...");
 
     await using var connection = await dataSource.OpenConnectionAsync();
     await using var transaction = await connection.BeginTransactionAsync();
 
-    var dropElapsed = await WiktionaryIndexMaintenance.DropAsync(connection, transaction, default);
-    Console.WriteLine($"  dropped existing indexes in {FormatDuration(dropElapsed)}");
+    // Iterate every partition that exists in this database. Per-partition
+    // drop+create keeps each language's indexes named distinctly
+    // (ix_wiktionary_entries_<lang>_lookup / _data) so they don't collide
+    // and so a future single-language re-import can rebuild just one set.
+    var partitions = await WiktionaryIndexMaintenance.ListPartitionLangCodesAsync(
+        connection, transaction, default);
+    if (partitions.Count == 0)
+    {
+        Console.WriteLine(
+            "  no partitions found — nothing to rebuild. Did you skip the import step?");
+    }
 
-    var createElapsed = await WiktionaryIndexMaintenance.CreateAsync(connection, transaction, default);
-    Console.WriteLine($"  built indexes in {FormatDuration(createElapsed)}");
+    foreach (var lang in partitions)
+    {
+        var dropElapsed = await WiktionaryIndexMaintenance.DropAsync(
+            connection, transaction, lang, default);
+        var createElapsed = await WiktionaryIndexMaintenance.CreateAsync(
+            connection, transaction, lang, default);
+        Console.WriteLine(
+            $"  {lang}: dropped in {FormatDuration(dropElapsed)}, built in {FormatDuration(createElapsed)}");
+    }
 
     await transaction.CommitAsync();
 

--- a/apps/api/src/Langoose.Corpus.DbTool/README.md
+++ b/apps/api/src/Langoose.Corpus.DbTool/README.md
@@ -93,7 +93,7 @@ dotnet run --project apps/api/src/Langoose.Corpus.DbTool -- \
 ```
 
 The importer prints progress every 50k entries during COPY plus a per-step
-breakdown on finish (`delete / drop indexes / copy / build indexes /
+breakdown on finish (`drop indexes / truncate / copy / build indexes /
 metadata / commit`). Ballpark timing on a local dev machine (Docker
 Postgres on a modern SSD, no competing load):
 
@@ -102,18 +102,20 @@ Postgres on a modern SSD, no competing load):
 | English  | ~900k   | 3–5 min | 1–3 min    | 5–8 min |
 | Russian  | ~150k   | 30–60 s | 30–60 s    | 1–2 min |
 
-The importer drops the JSONB GIN index and the `(lang_code, word, pos)`
-btree before COPY and rebuilds them afterwards, inside the same
-transaction. Per-row GIN maintenance on Wiktionary's nested JSONB is very
-slow; building in bulk is typically 10-30× faster. The build uses
+`wiktionary_entries` is LIST-partitioned by `lang_code` (#97). Each
+language gets its own partition `wiktionary_entries_<lang>` with its
+own pair of indexes — a `(lang_code, word, pos)` btree and a JSONB GIN
+on `data jsonb_path_ops`. The importer drops the partition's two
+indexes before COPY, TRUNCATEs the partition, COPYs new rows, and
+rebuilds those two indexes — all inside one transaction, only touching
+this language. Per-row GIN maintenance on Wiktionary's nested JSONB is
+very slow; building in bulk is typically 10-30× faster. The build uses
 `SET LOCAL maintenance_work_mem = '1GB'` and
 `max_parallel_maintenance_workers = 4` to keep posting-list sorting in
-memory and parallelise the merge — otherwise it spills to disk, which is
-punishing on Docker Desktop Windows. Adjust those two knobs in
+memory and parallelise the merge — otherwise it spills to disk, which
+is punishing on Docker Desktop Windows. Adjust those two knobs in
 `WiktionaryIndexMaintenance.cs` if your Postgres container has
-significantly less than 2 GB available. See #97 for the per-language
-partitioning follow-up that would localise the rebuild cost when many
-languages are loaded.
+significantly less than 2 GB available.
 
 **Multi-language bulk builds**: pass `--defer-indexes` to each
 `import-wiktionary` call, then run `rebuild-indexes` once at the end.
@@ -167,14 +169,15 @@ command per missing file.
 > 1. Starts local Postgres (`docker compose up -d postgres`)
 > 2. Applies the corpus schema (`init`, idempotent)
 > 3. Resets both source tables (`reset-wiktionary` + `reset-wordfreq`):
->    TRUNCATEs `wiktionary_entries` and `wordfreq_rankings`, clears
->    `source_version_*` metadata rows, drops the wiktionary indexes.
+>    drops every `wiktionary_entries_<lang>` partition, TRUNCATEs
+>    `wordfreq_rankings`, and clears `source_version_*` metadata rows.
 >    Both resets are required: `import-wordfreq` only deletes per
 >    `(lang, source)`, so a cross-date rebuild or a language dropped
->    from `LANGUAGES` would otherwise leave stale rankings behind. The
->    dump is thereby deterministic from the `LANGUAGES` list — anything
->    removed from the list since a previous rebuild is gone from the
->    new dump.
+>    from `LANGUAGES` would otherwise leave stale rankings behind, and
+>    a partition for a removed language would linger as an empty
+>    partition in the dump. The dump is thereby deterministic from the
+>    `LANGUAGES` list — anything removed from the list since a previous
+>    rebuild is gone from the new dump.
 > 4. Imports the wordfreq TSV per language via `import-wordfreq`.
 >    Required by the test rebuild (drives the frequency filter);
 >    included in the full rebuild so the published dump ships rankings.
@@ -284,9 +287,9 @@ each.
 | `init` | Apply embedded SQL schema files in order. Idempotent. |
 | `import-wiktionary --lang <code> --source <jsonl> [--source-version <ver>] [--limit <n>] [--frequency-filter-top <n>] [--defer-indexes]` | Bulk-load a Kaikki Wiktionary JSONL extract. Replaces existing rows for that language. `--frequency-filter-top` keeps only headwords in the top N of `wordfreq_rankings` (run `import-wordfreq` first). |
 | `import-wordfreq --lang <code> --source <tsv> [--source-version <ver>]` | Bulk-load a wordfreq frequency-ranking TSV (`word\trank\tzipf_score`, `.gz` allowed). Replaces existing rows for that (lang, source). Fetch the TSV with `scripts/download-wordfreq.sh`. |
-| `reset-wiktionary` | Truncate `wiktionary_entries`, clear `source_version_wiktionary_*` metadata, drop indexes. Use at the start of a bulk multi-language rebuild. |
+| `reset-wiktionary` | Drop every `wiktionary_entries_<lang>` partition (and its indexes) and clear `source_version_wiktionary_*` metadata. Use at the start of a bulk multi-language rebuild — partitions for languages no longer in `LANGUAGES` are removed, not just emptied. |
 | `reset-wordfreq` | Truncate `wordfreq_rankings`, clear `source_version_wordfreq_*` metadata. Required at the start of a rebuild — `import-wordfreq` only deletes per `(lang, source)`, so cross-date rebuilds or dropped languages would otherwise accumulate stale rankings. |
-| `rebuild-indexes` | Drop and recreate the `wiktionary_entries` indexes. Idempotent. |
+| `rebuild-indexes` | Iterate every `wiktionary_entries_<lang>` partition and drop+recreate its two indexes. Idempotent. Used as the final step of a multi-language `--defer-indexes` build. |
 
 Future commands tracked under #92: `import-cefrj`, `import-tatoeba`,
 `dump`, `restore`.

--- a/apps/api/src/Langoose.Corpus.DbTool/WiktionaryIndexMaintenance.cs
+++ b/apps/api/src/Langoose.Corpus.DbTool/WiktionaryIndexMaintenance.cs
@@ -1,51 +1,104 @@
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using Npgsql;
 
 namespace Langoose.Corpus.DbTool;
 
 /// <summary>
-/// Manages the drop/rebuild of the wiktionary_entries indexes. Kept
-/// separate from <c>WiktionaryImporter</c> so it can be reused by the
-/// standalone <c>rebuild-indexes</c> command (for finishing a bulk
-/// multi-language build after all per-lang COPYs have run with
-/// <c>--defer-indexes</c>).
+/// Per-partition operations for <c>wiktionary_entries</c>. The DDL
+/// templates themselves live in <c>002_wiktionary.sql</c> as PL/pgSQL
+/// helpers (see <c>corpus_wiktionary_*</c> functions); this class is a
+/// thin C# RPC layer that passes <c>lang_code</c> as a parameter and
+/// times the call.
 /// </summary>
 public static class WiktionaryIndexMaintenance
 {
-    private const string DropIndexesSql =
-        """
-        DROP INDEX IF EXISTS ix_wiktionary_entries_lookup;
-        DROP INDEX IF EXISTS ix_wiktionary_entries_data;
-        """;
+    // Matches the regex inside corpus_wiktionary_assert_lang_code() in
+    // 002_wiktionary.sql. Duplicated as a fast fail-fast check so callers
+    // get a clean ArgumentException before opening a connection; the SQL
+    // function is the authoritative gate (it also runs when these helpers
+    // are invoked from psql).
+    private static readonly Regex LangCodePattern = new("^[a-z][a-z0-9_]*$", RegexOptions.Compiled);
 
-    // maintenance_work_mem defaults to 64MB, which forces GIN's bulk build
-    // to spill posting-list sorts to disk for any non-trivial corpus — and
-    // disk spills on Docker Desktop Windows are very slow. SET LOCAL gives
-    // the build a large in-memory budget just for this transaction;
-    // parallel workers further amortise the posting-list merge. Values
-    // tuned for Docker Desktop defaults (typically 4-8 GB container
-    // memory); reduce if your Postgres container is more constrained.
-    private const string CreateIndexesSql =
-        """
-        SET LOCAL maintenance_work_mem = '1GB';
-        SET LOCAL max_parallel_maintenance_workers = 4;
+    public static string PartitionName(string langCode)
+    {
+        ValidateLangCode(langCode);
+        return "wiktionary_entries_" + langCode;
+    }
 
-        CREATE INDEX ix_wiktionary_entries_lookup
-            ON wiktionary_entries (lang_code, word, pos);
-        CREATE INDEX ix_wiktionary_entries_data
-            ON wiktionary_entries USING GIN (data jsonb_path_ops);
-        """;
+    public static async Task EnsurePartitionAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        string langCode,
+        CancellationToken ct)
+    {
+        ValidateLangCode(langCode);
+        await CallVoidFunctionAsync(
+            connection, transaction, "corpus_wiktionary_ensure_partition", langCode, ct);
+    }
+
+    public static async Task DropPartitionAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        string langCode,
+        CancellationToken ct)
+    {
+        ValidateLangCode(langCode);
+        await CallVoidFunctionAsync(
+            connection, transaction, "corpus_wiktionary_drop_partition", langCode, ct);
+    }
+
+    public static async Task TruncatePartitionAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        string langCode,
+        CancellationToken ct)
+    {
+        ValidateLangCode(langCode);
+        await CallVoidFunctionAsync(
+            connection, transaction, "corpus_wiktionary_truncate_partition", langCode, ct);
+    }
 
     public static async Task<TimeSpan> DropAsync(
         NpgsqlConnection connection,
         NpgsqlTransaction? transaction,
+        string langCode,
         CancellationToken ct)
     {
+        ValidateLangCode(langCode);
+
+        var stopwatch = Stopwatch.StartNew();
+        await CallVoidFunctionAsync(
+            connection, transaction, "corpus_wiktionary_drop_partition_indexes", langCode, ct);
+        return stopwatch.Elapsed;
+    }
+
+    public static async Task<TimeSpan> CreateAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        string langCode,
+        CancellationToken ct)
+    {
+        ValidateLangCode(langCode);
+
         var stopwatch = Stopwatch.StartNew();
 
+        // SET LOCAL has to live at the transaction level — issuing it
+        // inside the SQL function only affects the function's call
+        // frame, not the surrounding CREATE INDEX. maintenance_work_mem
+        // defaults to 64 MB, which forces GIN's bulk build to spill
+        // posting-list sorts to disk; 1 GB plus 4 parallel workers
+        // keeps the merge in memory and is calibrated for Docker
+        // Desktop defaults (~4-8 GB container memory). Reduce if your
+        // Postgres container has significantly less.
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText = DropIndexesSql;
+        command.CommandText = """
+            SET LOCAL maintenance_work_mem = '1GB';
+            SET LOCAL max_parallel_maintenance_workers = 4;
+            SELECT corpus_wiktionary_create_partition_indexes(@lang_code);
+            """;
+        command.Parameters.AddWithValue("lang_code", langCode);
         command.CommandTimeout = 0;
 
         await command.ExecuteNonQueryAsync(ct);
@@ -53,20 +106,46 @@ public static class WiktionaryIndexMaintenance
         return stopwatch.Elapsed;
     }
 
-    public static async Task<TimeSpan> CreateAsync(
+    public static async Task<IReadOnlyList<string>> ListPartitionLangCodesAsync(
         NpgsqlConnection connection,
         NpgsqlTransaction? transaction,
         CancellationToken ct)
     {
-        var stopwatch = Stopwatch.StartNew();
-
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText = CreateIndexesSql;
+        command.CommandText = "SELECT * FROM corpus_wiktionary_list_partition_lang_codes()";
+
+        var langCodes = new List<string>();
+        await using var reader = await command.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+            langCodes.Add(reader.GetString(0));
+
+        return langCodes;
+    }
+
+    private static async Task CallVoidFunctionAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        string functionName,
+        string langCode,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = $"SELECT {functionName}(@lang_code)";
+        command.Parameters.AddWithValue("lang_code", langCode);
         command.CommandTimeout = 0;
 
         await command.ExecuteNonQueryAsync(ct);
+    }
 
-        return stopwatch.Elapsed;
+    private static void ValidateLangCode(string langCode)
+    {
+        if (string.IsNullOrEmpty(langCode) || !LangCodePattern.IsMatch(langCode))
+        {
+            throw new ArgumentException(
+                $"Invalid lang_code '{langCode}': must match [a-z][a-z0-9_]*.",
+                nameof(langCode));
+        }
     }
 }

--- a/apps/api/tests/Langoose.Corpus.IntegrationTests/CorpusInitializerTests.cs
+++ b/apps/api/tests/Langoose.Corpus.IntegrationTests/CorpusInitializerTests.cs
@@ -6,8 +6,23 @@ using Xunit;
 
 namespace Langoose.Corpus.IntegrationTests;
 
-public sealed class CorpusInitializerTests(PostgresFixture postgres) : IClassFixture<PostgresFixture>
+public sealed class CorpusInitializerTests(PostgresFixture postgres)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
 {
+    public async Task InitializeAsync()
+    {
+        // Each test starts on a fresh public schema. The container is
+        // shared across the class via PostgresFixture, but tests in this
+        // file assert on first-init state (e.g. that a fresh DB lands
+        // wiktionary_entries as a partitioned table). Recreating the
+        // schema is cheap relative to the container start.
+        await using var connection = await postgres.DataSource.OpenConnectionAsync();
+        await connection.ExecuteAsync(
+            "DROP SCHEMA public CASCADE; CREATE SCHEMA public;");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
     [Fact]
     public async Task ApplySchemaAsync_OnFreshDatabase_CreatesAllExpectedTables()
     {
@@ -25,6 +40,57 @@ public sealed class CorpusInitializerTests(PostgresFixture postgres) : IClassFix
 
         tableNames.Should().Contain("corpus_metadata");
         tableNames.Should().Contain("wiktionary_entries");
+    }
+
+    [Fact]
+    public async Task ApplySchemaAsync_OnFreshDatabase_CreatesWiktionaryEntriesAsPartitionedTable()
+    {
+        var initializer = new CorpusInitializer(postgres.DataSource);
+
+        await initializer.ApplySchemaAsync();
+
+        await using var connection = await postgres.DataSource.OpenConnectionAsync();
+        // pg_class.relkind 'p' indicates a partitioned table. If
+        // 002_wiktionary.sql lost the PARTITION BY clause this test fails.
+        var relkind = await connection.QuerySingleAsync<char>(
+            """
+            SELECT c.relkind
+            FROM pg_class c
+            JOIN pg_namespace ns ON ns.oid = c.relnamespace
+            WHERE c.relname = 'wiktionary_entries' AND ns.nspname = 'public'
+            """);
+
+        relkind.Should().Be('p');
+    }
+
+    [Fact]
+    public async Task ApplySchemaAsync_OnFreshDatabase_RegistersWiktionaryHelperFunctions()
+    {
+        var initializer = new CorpusInitializer(postgres.DataSource);
+
+        await initializer.ApplySchemaAsync();
+
+        await using var connection = await postgres.DataSource.OpenConnectionAsync();
+        var functions = (await connection.QueryAsync<string>(
+            """
+            SELECT proname
+            FROM pg_proc p
+            JOIN pg_namespace ns ON ns.oid = p.pronamespace
+            WHERE ns.nspname = 'public'
+              AND proname LIKE 'corpus_wiktionary_%'
+            ORDER BY proname
+            """)).ToArray();
+
+        // Lock the helper surface — these names are part of the contract
+        // between 002_wiktionary.sql and WiktionaryIndexMaintenance.cs.
+        functions.Should().Equal(
+            "corpus_wiktionary_assert_lang_code",
+            "corpus_wiktionary_create_partition_indexes",
+            "corpus_wiktionary_drop_partition",
+            "corpus_wiktionary_drop_partition_indexes",
+            "corpus_wiktionary_ensure_partition",
+            "corpus_wiktionary_list_partition_lang_codes",
+            "corpus_wiktionary_truncate_partition");
     }
 
     [Fact]

--- a/apps/api/tests/Langoose.Corpus.IntegrationTests/WiktionaryImporterTests.cs
+++ b/apps/api/tests/Langoose.Corpus.IntegrationTests/WiktionaryImporterTests.cs
@@ -23,16 +23,31 @@ public sealed class WiktionaryImporterTests(PostgresFixture postgres)
         // Reset to a clean slate before each test so ordering doesn't
         // matter and future tests can't be broken by stale data. The
         // container itself is still reused across the class (disposable
-        // per class via PostgresFixture) — truncating is cheaper than
-        // booting a container per test.
+        // per class via PostgresFixture). With #97 wiktionary_entries is
+        // LIST-partitioned, so we drop every partition individually
+        // before wiping wordfreq + metadata.
         await using var connection = await postgres.DataSource.OpenConnectionAsync();
-        await using var command = connection.CreateCommand();
-        command.CommandText = """
-            TRUNCATE TABLE wiktionary_entries;
-            TRUNCATE TABLE wordfreq_rankings;
-            DELETE FROM corpus_metadata;
-            """;
-        await command.ExecuteNonQueryAsync();
+        await using var transaction = await connection.BeginTransactionAsync();
+
+        var partitions = await WiktionaryIndexMaintenance.ListPartitionLangCodesAsync(
+            connection, transaction, default);
+        foreach (var lang in partitions)
+        {
+            await WiktionaryIndexMaintenance.DropPartitionAsync(
+                connection, transaction, lang, default);
+        }
+
+        await using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = """
+                TRUNCATE TABLE wordfreq_rankings;
+                DELETE FROM corpus_metadata;
+                """;
+            await command.ExecuteNonQueryAsync();
+        }
+
+        await transaction.CommitAsync();
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
@@ -160,19 +175,14 @@ public sealed class WiktionaryImporterTests(PostgresFixture postgres)
     }
 
     [Fact]
-    public async Task ImportAsync_WithDeferIndexes_LeavesIndexesMissingUntilRebuild()
+    public async Task ImportAsync_WithDeferIndexes_LeavesPartitionIndexesMissingUntilRebuild()
     {
-        // Bulk-build pattern (scripts/build-*-corpus-dump.sh): drop indexes
-        // up-front via `reset-wiktionary`, import each language with
-        // --defer-indexes (just COPY, no per-lang DROP/REBUILD), then
-        // `rebuild-indexes` at the end restores them.
-        await using (var setupConnection = await postgres.DataSource.OpenConnectionAsync())
-        await using (var setupTx = await setupConnection.BeginTransactionAsync())
-        {
-            await WiktionaryIndexMaintenance.DropAsync(setupConnection, setupTx, default);
-            await setupTx.CommitAsync();
-        }
-
+        // Bulk-build pattern (scripts/rebuild-*-corpus-dump.sh): wipe
+        // partitions via `reset-wiktionary`, import each language with
+        // --defer-indexes (creates the partition + COPY, no per-lang
+        // DROP/REBUILD of partition indexes), then `rebuild-indexes` at
+        // the end builds indexes on every partition. Per #97 each
+        // partition has its own pair of indexes.
         var en = new WiktionaryImporter(postgres.DataSource, "en", "test-1", deferIndexes: true);
         var ru = new WiktionaryImporter(postgres.DataSource, "ru", "test-1", deferIndexes: true);
 
@@ -181,38 +191,47 @@ public sealed class WiktionaryImporterTests(PostgresFixture postgres)
 
         await using var connection = await postgres.DataSource.OpenConnectionAsync();
 
-        var indexes = (await connection.QueryAsync<string>(
+        var indexesBefore = (await connection.QueryAsync<string>(
             """
             SELECT indexname FROM pg_indexes
-            WHERE tablename = 'wiktionary_entries'
-              AND indexname IN ('ix_wiktionary_entries_lookup', 'ix_wiktionary_entries_data')
+            WHERE schemaname = 'public'
+              AND indexname LIKE 'ix_wiktionary_entries_%'
             """)).ToArray();
 
-        indexes.Should().BeEmpty();
+        indexesBefore.Should().BeEmpty();
 
-        // Both languages' rows are in place despite no indexes.
+        // Both languages' rows are in place despite no indexes — COPY
+        // routed each row to its partition by lang_code.
         var totalRows = await connection.ExecuteScalarAsync<long>(
             "SELECT COUNT(*) FROM wiktionary_entries");
         totalRows.Should().Be(6 + 3);  // EN fixture has 6, RU has 3
 
-        // rebuild-indexes restores both indexes.
+        // rebuild-indexes builds the per-partition indexes.
         await using var rebuildConnection = await postgres.DataSource.OpenConnectionAsync();
         await using var rebuildTx = await rebuildConnection.BeginTransactionAsync();
-        await WiktionaryIndexMaintenance.DropAsync(rebuildConnection, rebuildTx, default);
-        await WiktionaryIndexMaintenance.CreateAsync(rebuildConnection, rebuildTx, default);
+        var partitions = await WiktionaryIndexMaintenance.ListPartitionLangCodesAsync(
+            rebuildConnection, rebuildTx, default);
+        foreach (var lang in partitions)
+        {
+            await WiktionaryIndexMaintenance.DropAsync(rebuildConnection, rebuildTx, lang, default);
+            await WiktionaryIndexMaintenance.CreateAsync(rebuildConnection, rebuildTx, lang, default);
+        }
         await rebuildTx.CommitAsync();
 
         var indexesAfter = (await connection.QueryAsync<string>(
             """
             SELECT indexname FROM pg_indexes
-            WHERE tablename = 'wiktionary_entries'
-              AND indexname IN ('ix_wiktionary_entries_lookup', 'ix_wiktionary_entries_data')
+            WHERE schemaname = 'public'
+              AND indexname LIKE 'ix_wiktionary_entries_%'
+            ORDER BY indexname
             """)).ToArray();
 
         indexesAfter.Should().BeEquivalentTo(new[]
         {
-            "ix_wiktionary_entries_lookup",
-            "ix_wiktionary_entries_data"
+            "ix_wiktionary_entries_en_data",
+            "ix_wiktionary_entries_en_lookup",
+            "ix_wiktionary_entries_ru_data",
+            "ix_wiktionary_entries_ru_lookup"
         });
     }
 
@@ -390,5 +409,132 @@ public sealed class WiktionaryImporterTests(PostgresFixture postgres)
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*--frequency-filter-top 100*wordfreq_rankings*no rows for lang_code='en'*");
+    }
+
+    [Fact]
+    public async Task ImportAsync_FirstRunForLanguage_CreatesPartitionAndIndexes()
+    {
+        var importer = new WiktionaryImporter(postgres.DataSource, "en", "test-1");
+
+        await importer.ImportAsync(FixtureEnPath);
+
+        await using var connection = await postgres.DataSource.OpenConnectionAsync();
+
+        // Partition exists with the expected name.
+        var partitions = (await connection.QueryAsync<string>(
+            """
+            SELECT c.relname
+            FROM pg_inherits i
+            JOIN pg_class c ON c.oid = i.inhrelid
+            JOIN pg_class p ON p.oid = i.inhparent
+            WHERE p.relname = 'wiktionary_entries'
+            ORDER BY c.relname
+            """)).ToArray();
+        partitions.Should().Equal("wiktionary_entries_en");
+
+        // Per-partition indexes were created with predictable names.
+        var indexes = (await connection.QueryAsync<string>(
+            """
+            SELECT indexname FROM pg_indexes
+            WHERE schemaname = 'public' AND tablename = 'wiktionary_entries_en'
+            ORDER BY indexname
+            """)).ToArray();
+        indexes.Should().Equal(
+            "ix_wiktionary_entries_en_data",
+            "ix_wiktionary_entries_en_lookup");
+    }
+
+    [Fact]
+    public async Task ImportAsync_RunTwice_PartitionCreationIsIdempotent()
+    {
+        // Re-importing the same language must reuse the existing partition
+        // (CREATE TABLE IF NOT EXISTS path), drop+recreate only that
+        // partition's indexes, and leave the row count at 6 — not 12.
+        var importer = new WiktionaryImporter(postgres.DataSource, "en", "test-1");
+
+        await importer.ImportAsync(FixtureEnPath);
+        await importer.ImportAsync(FixtureEnPath);
+
+        await using var connection = await postgres.DataSource.OpenConnectionAsync();
+
+        var partitionCount = await connection.ExecuteScalarAsync<long>(
+            """
+            SELECT COUNT(*)
+            FROM pg_inherits i
+            JOIN pg_class p ON p.oid = i.inhparent
+            WHERE p.relname = 'wiktionary_entries'
+            """);
+        partitionCount.Should().Be(1);
+
+        var rowCount = await connection.ExecuteScalarAsync<long>(
+            "SELECT COUNT(*) FROM wiktionary_entries WHERE lang_code = 'en'");
+        rowCount.Should().Be(6);
+
+        // Indexes are present after the second import (rebuilt as part of
+        // the second run, not duplicated).
+        var indexCount = await connection.ExecuteScalarAsync<long>(
+            """
+            SELECT COUNT(*) FROM pg_indexes
+            WHERE schemaname = 'public' AND tablename = 'wiktionary_entries_en'
+            """);
+        indexCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ImportAsync_SingleLanguageReimport_LeavesOtherPartitionsIndexesIntact()
+    {
+        // The headline #97 win: re-importing one language must NOT touch
+        // any other partition's indexes. We capture each EN index's
+        // pg_class.oid before the RU re-import; if the EN indexes are
+        // recreated (rather than left alone), the oids change.
+        const string EnIndexOidQuery = """
+            SELECT c.relname AS indexname, c.oid::bigint AS oid
+            FROM pg_index i
+            JOIN pg_class c ON c.oid = i.indexrelid
+            JOIN pg_class t ON t.oid = i.indrelid
+            WHERE t.relname = 'wiktionary_entries_en'
+            ORDER BY c.relname
+            """;
+
+        var en = new WiktionaryImporter(postgres.DataSource, "en", "test-1");
+        var ru = new WiktionaryImporter(postgres.DataSource, "ru", "test-1");
+
+        await en.ImportAsync(FixtureEnPath);
+        await ru.ImportAsync(FixtureRuPath);
+
+        await using var connection = await postgres.DataSource.OpenConnectionAsync();
+
+        var enIndexOidsBefore = (await connection.QueryAsync<(string indexname, long oid)>(
+            EnIndexOidQuery)).ToArray();
+        enIndexOidsBefore.Should().HaveCount(2);
+
+        // Re-import RU. The EN partition and its indexes must be untouched.
+        var ruReimport = new WiktionaryImporter(postgres.DataSource, "ru", "test-2");
+        await ruReimport.ImportAsync(FixtureRuPath);
+
+        var enIndexOidsAfter = (await connection.QueryAsync<(string indexname, long oid)>(
+            EnIndexOidQuery)).ToArray();
+
+        enIndexOidsAfter.Should().BeEquivalentTo(enIndexOidsBefore);
+
+        // EN row count is also unaffected.
+        var enRowCount = await connection.ExecuteScalarAsync<long>(
+            "SELECT COUNT(*) FROM wiktionary_entries WHERE lang_code = 'en'");
+        enRowCount.Should().Be(6);
+    }
+
+    [Fact]
+    public async Task ImportAsync_WithUnsafeLangCode_RejectsBeforeIssuingDdl()
+    {
+        // Defence in depth: lang_code is interpolated into partition/index
+        // DDL (Postgres doesn't accept parameters there), so anything that
+        // isn't a strict identifier must throw before any DDL is issued.
+        // Mirrors the WiktionaryIndexMaintenance.ValidateLangCode contract.
+        var importer = new WiktionaryImporter(postgres.DataSource, "en'; DROP TABLE--", "test-1");
+
+        var act = async () => await importer.ImportAsync(FixtureEnPath);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*Invalid lang_code*");
     }
 }

--- a/docs/agent/enrichment-guidance.md
+++ b/docs/agent/enrichment-guidance.md
@@ -120,10 +120,36 @@ Concrete consequences of "source-first":
   pure derived data; if benchmarks ever show containment as too slow, it
   can be built as a follow-up step without re-importing the source.
 
-Invariant for query authors: **always filter by `lang_code`**. Every
-index on the table is scoped by language; every partitioning scheme we'd
-adopt later (#97 territory) is keyed by language. Queries that omit
-`lang_code` will full-scan and will break once we partition.
+### Partitioning by `lang_code` (#97)
+
+`wiktionary_entries` is LIST-partitioned by `lang_code`. Each language
+gets its own partition `wiktionary_entries_<lang>` with its own indexes
+(`ix_wiktionary_entries_<lang>_lookup` on `(lang_code, word, pos)` and
+`ix_wiktionary_entries_<lang>_data` GIN on `data jsonb_path_ops`).
+Partitions are created on demand by the importer — the parent ships
+empty with no up-front list of supported languages, and dropping a
+language from `LANGUAGES` removes its partition entirely on the next
+`reset-wiktionary`.
+
+The motivation is purely operational: with N languages loaded, a
+single-language re-import without partitioning rebuilds GIN over the
+whole table (millions of rows scanned) before COPY can land. With
+partitioning, the rebuild scans only the partition we just truncated
+and reloaded. Other partitions' indexes are not touched.
+
+Per-partition DDL (create/drop partition, drop/create the two indexes,
+truncate, list) lives in `002_wiktionary.sql` as `corpus_wiktionary_*`
+PL/pgSQL helpers. The C# importer is a thin caller that passes
+`lang_code` as a parameter; `format(%I, %L)` inside the helpers does
+the identifier and literal quoting. Add or change an index by editing
+`corpus_wiktionary_create_partition_indexes` — no C# change needed.
+
+Invariant for query authors: **always filter by `lang_code`**. The
+planner needs that predicate to prune to the right partition; without
+it, queries either scan every partition (slow) or fail to use any
+local index (slower). The query layout already reflects this — every
+production query against `wiktionary_entries` filters on `lang_code`
+as the leading column, and the integration tests assert it.
 
 Sibling tables under the same source-first principle:
 - `wordfreq_rankings` (flat) — frequency ranks per word, per source


### PR DESCRIPTION
Closes #97. Sub-issue of #92.

## Summary

LIST-partition `wiktionary_entries` by `lang_code` so a single-language re-import only drops/rebuilds that partition's indexes instead of paying the cost across the whole table.

- Parent table now ships empty with `PARTITION BY LIST (lang_code)`; partitions are created on demand by the importer (`wiktionary_entries_<lang>`).
- Each partition carries its own `(lang_code, word, pos)` btree and `data jsonb_path_ops` GIN, named `ix_wiktionary_entries_<lang>_lookup` / `_data`.
- Per-partition DDL (create/drop partition, truncate, drop/create the two indexes, list) lives in `002_wiktionary.sql` as `corpus_wiktionary_*` PL/pgSQL helpers. `format(%I, %L)` closes the DDL injection vector; a regex check in PL/pgSQL plus a fast-fail in C# enforce the lang_code identifier convention.
- `WiktionaryIndexMaintenance.cs` collapses to a thin RPC layer that passes `lang_code` as a parameter. Index structure is now visible alongside the table definition — adding a third index means editing one PL/pgSQL function.
- `reset-wiktionary` drops every partition rather than truncating the parent, so a language removed from LANGUAGES disappears from the next dump rather than lingering as an empty partition.
- `rebuild-indexes` iterates every partition and drops+recreates its two indexes (sequential per partition; each individual `CREATE INDEX` still uses `max_parallel_maintenance_workers = 4`).

## Importer flow per language

Ensure partition (idempotent) → drop partition's two indexes → `TRUNCATE` the partition → `COPY` into the parent (Postgres routes by `lang_code`) → rebuild the partition's two indexes. `--defer-indexes` mode skips drop/truncate/rebuild so the bulk multi-language flow can do one `rebuild-indexes` sweep at the end.

## Out of scope

- **Schema versioning**: skipped per discussion. The deploy model is drop-and-recreate (`pg_restore --clean --if-exists`), so a stamped `schema_version` doesn't earn its keep.
- **Parallel rebuild across partitions**: sequential is the safer default; memory pressure (1 GB `maintenance_work_mem` × N) and CPU contention (`max_parallel_maintenance_workers = 4` × N) usually eat the wall-clock win on dev hardware.
- **Concurrent index creation** (`CREATE INDEX CONCURRENTLY`): imports are offline; plain `CREATE INDEX` inside the transaction is fine.

## Perf

The headline #97 claim — RU re-import ~1–2 min instead of ~4–6 min — assumes 5+ languages loaded so the GIN rebuild scope difference matters. At 2 languages (EN+RU) the bulk-build wall-clock is comparable to pre-#97 (full rebuild measured ~7m20s, in line with the existing 5–10 min ballpark). The structural win — single-lang re-import scope — has not been benchmarked at 5-language scale; will revisit when the 3rd/4th language lands.

## Test plan

- [x] `dotnet test apps/api/tests/Langoose.Corpus.IntegrationTests` (27 tests pass)
- [x] `dotnet test apps/api/tests/Langoose.Core.UnitTests` (16 pass)
- [x] `dotnet test apps/api/tests/Langoose.Api.IntegrationTests` (25 pass)
- [x] Solution build clean (0 warnings, 0 errors)
- [x] Local full rebuild end-to-end (`scripts/rebuild-full-corpus-dump.sh`, EN+RU)
- [ ] Single-language re-import benchmark (deferred — modest win at 2-language scale)
- [ ] Restore the resulting dump on staging (Corpus Restore workflow) and confirm the partitioned schema lands intact

## New tests added

- `ApplySchemaAsync_OnFreshDatabase_CreatesWiktionaryEntriesAsPartitionedTable` — guards the `PARTITION BY` clause
- `ApplySchemaAsync_OnFreshDatabase_RegistersWiktionaryHelperFunctions` — locks the PL/pgSQL helper surface
- `ImportAsync_FirstRunForLanguage_CreatesPartitionAndIndexes`
- `ImportAsync_RunTwice_PartitionCreationIsIdempotent`
- `ImportAsync_SingleLanguageReimport_LeavesOtherPartitionsIndexesIntact` (verified via `pg_class.oid` stability)
- `ImportAsync_WithUnsafeLangCode_RejectsBeforeIssuingDdl`