### PR TITLE
feat(dictionary): sense-aware schema with senses, translations rank, and staging (#94)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ Keep this table in sync when adding or removing docs under `docs/agent/`.
 | `docs/agent/frontend-conventions.md` | React patterns, TypeScript config, CSS approach |
 | `docs/agent/api-contracts.md` | DTO mapping, response shapes, frontend type alignment |
 | `docs/agent/dictionary-rules.md` | Visibility, form-based dedup, CSV import/export, product invariants |
+| `docs/agent/dictionary-schema-design.md` | ADR for senses, phrases, ranked translations, provenance, staging tables |
 | `docs/agent/study-engine.md` | Study cards, answer evaluation, grading tolerances, scheduling |
 | `docs/agent/enrichment-guidance.md` | Provider interface, worker, content generation, rate limiting |
 | `docs/agent/auth-hosting.md` | Cookies, antiforgery, OpenIddict, proxy, Data Protection |
@@ -60,6 +61,7 @@ Keep this table in sync when adding or removing docs under `docs/agent/`.
 | `docs/agent/frontend-conventions.md` | `langoose-react-typescript` | |
 | `docs/agent/api-contracts.md` | `langoose-api-contracts` | |
 | `docs/agent/dictionary-rules.md` | `langoose-dictionary-imports` | |
+| `docs/agent/dictionary-schema-design.md` | `doc-only` | ADR; supersedes flat-translations model — see efcore-structure for current entity shape |
 | `docs/agent/study-engine.md` | `langoose-study-engine` | |
 | `docs/agent/enrichment-guidance.md` | `doc-only` | No dedicated skill yet |
 | `docs/agent/auth-hosting.md` | `langoose-auth-hosting` | |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Keep this table in sync when adding or removing docs under `docs/agent/`.
 | `docs/agent/frontend-conventions.md` | React patterns, TypeScript config, CSS approach |
 | `docs/agent/api-contracts.md` | DTO mapping, response shapes, frontend type alignment |
 | `docs/agent/dictionary-rules.md` | Visibility, form-based dedup, CSV import/export, product invariants |
+| `docs/agent/dictionary-schema-design.md` | ADR for senses, phrases, ranked translations, provenance, staging tables |
 | `docs/agent/study-engine.md` | Study cards, answer evaluation, grading tolerances, scheduling |
 | `docs/agent/enrichment-guidance.md` | Provider interface, worker, content generation, rate limiting |
 | `docs/agent/auth-hosting.md` | Cookies, antiforgery, OpenIddict, proxy, Data Protection |

--- a/apps/api/src/Langoose.Core/Services/DictionaryService.cs
+++ b/apps/api/src/Langoose.Core/Services/DictionaryService.cs
@@ -222,8 +222,10 @@ public sealed class DictionaryService(AppDbContext dbContext) : IDictionaryServi
         var entries = await dbContext.UserDictionaryEntries
             .AsNoTracking()
             .Where(x => x.UserId == userId)
-            .Include(x => x.SourceEntry)
-            .ThenInclude(x => x!.Translations)
+            .Include(x => x.SourceEntry).ThenInclude(x => x!.Senses)
+                .ThenInclude(s => s.Translations.OrderBy(t => t.Rank))
+                .ThenInclude(t => t.TargetSense)
+                .ThenInclude(s => s.DictionaryEntry)
             .OrderBy(x => x.UserInputTerm)
             .ToListAsync(cancellationToken);
 
@@ -236,9 +238,12 @@ public sealed class DictionaryService(AppDbContext dbContext) : IDictionaryServi
                 ?? entry.UserInputTranslation
                 ?? entry.UserInputTerm;
 
-            var russianText = entry.SourceEntry?.Translations
-                .Where(x => x.Language == "ru")
-                .Select(x => x.Text)
+            var russianText = entry.SourceEntry?.Senses
+                .OrderBy(s => s.SenseIndex)
+                .SelectMany(s => s.Translations)
+                .Select(t => t.TargetSense.DictionaryEntry)
+                .Where(e => e.Language == "ru")
+                .Select(e => e.Text)
                 .FirstOrDefault()
                 ?? entry.UserInputTerm;
 

--- a/apps/api/src/Langoose.Core/Services/EnrichmentProcessor.cs
+++ b/apps/api/src/Langoose.Core/Services/EnrichmentProcessor.cs
@@ -18,8 +18,10 @@ public sealed class EnrichmentProcessor(
         var now = DateTimeOffset.UtcNow;
 
         var pendingItems = await dbContext.UserDictionaryEntries
-            .Include(x => x.SourceEntry).ThenInclude(x => x!.Translations)
-            .Include(x => x.TargetEntry)
+            .Include(x => x.SourceEntry).ThenInclude(x => x!.Senses)
+                .ThenInclude(x => x.Translations).ThenInclude(x => x.TargetSense)
+                .ThenInclude(x => x.DictionaryEntry)
+            .Include(x => x.TargetEntry).ThenInclude(x => x!.Senses)
             .Where(x => x.EnrichmentStatus == EnrichmentStatus.Pending
                 || (x.EnrichmentStatus == EnrichmentStatus.ProviderError && x.EnrichmentAttempts < maxRetries))
             .Where(x => x.EnrichmentNotBefore == null || x.EnrichmentNotBefore <= now)
@@ -52,7 +54,9 @@ public sealed class EnrichmentProcessor(
             var texts = lookupKeys.Select(x => x.Text).Distinct().ToArray();
 
             var dbEntries = await dbContext.DictionaryEntries
-                .Include(x => x.Translations)
+                .Include(x => x.Senses)
+                    .ThenInclude(x => x.Translations).ThenInclude(x => x.TargetSense)
+                    .ThenInclude(x => x.DictionaryEntry)
                 .Where(x => languages.Contains(x.Language) && texts.Contains(x.Text))
                 .ToArrayAsync(cancellationToken);
 
@@ -85,13 +89,17 @@ public sealed class EnrichmentProcessor(
                 }
                 else
                 {
-                    item.TargetEntry = item.SourceEntry?.Translations
-                        .FirstOrDefault(x => x.Language == item.TargetLanguage && x.PartOfSpeech == item.PartOfSpeech);
+                    item.TargetEntry = item.SourceEntry?.Senses
+                        .SelectMany(s => s.Translations)
+                        .Select(t => t.TargetSense.DictionaryEntry)
+                        .FirstOrDefault(e => e.Language == item.TargetLanguage && e.PartOfSpeech == item.PartOfSpeech);
                 }
             }
 
             var hasLink = item.SourceEntry is not null && item.TargetEntry is not null
-                && item.SourceEntry.Translations.Any(x => x.Id == item.TargetEntry.Id);
+                && item.SourceEntry.Senses
+                    .SelectMany(s => s.Translations)
+                    .Any(t => t.TargetSense.DictionaryEntryId == item.TargetEntry.Id);
 
             if (item.SourceEntry is not null && item.TargetEntry is not null && hasLink)
             {
@@ -156,8 +164,8 @@ public sealed class EnrichmentProcessor(
                         item.TargetEntry = CreateBaseEntryOrThrow(result.TargetEntries, lang, pos, now);
                         CreateDerivedEntries(result.TargetEntries, item.TargetEntry, lang, pos, now);
                     }
-                    
-                    item.SourceEntry.Translations.Add(item.TargetEntry);
+
+                    LinkSenses(item.SourceEntry, item.TargetEntry, now);
                     item.EnrichmentStatus = EnrichmentStatus.Enriched;
                     item.UpdatedAtUtc = now;
                 }
@@ -181,6 +189,17 @@ public sealed class EnrichmentProcessor(
         var entry = MakeEntry(baseSrc, language, partOfSpeech, null, now);
         dbContext.DictionaryEntries.Add(entry);
 
+        var sense = new Sense
+        {
+            Id = Guid.CreateVersion7(),
+            DictionaryEntryId = entry.Id,
+            SenseIndex = 0,
+            CreatedAtUtc = now,
+            UpdatedAtUtc = now
+        };
+        entry.Senses.Add(sense);
+        dbContext.Senses.Add(sense);
+
         return entry;
     }
 
@@ -192,6 +211,33 @@ public sealed class EnrichmentProcessor(
 
         foreach (var src in enriched.Where(x => !x.IsBaseForm))
             dbContext.DictionaryEntries.Add(MakeEntry(src, language, partOfSpeech, baseEntry.Id, now));
+    }
+
+    private void LinkSenses(DictionaryEntry source, DictionaryEntry target, DateTimeOffset now)
+    {
+        var sourceSense = source.Senses.OrderBy(x => x.SenseIndex).FirstOrDefault()
+            ?? throw new InvalidOperationException($"Source entry {source.Id} has no senses to link.");
+        var targetSense = target.Senses.OrderBy(x => x.SenseIndex).FirstOrDefault()
+            ?? throw new InvalidOperationException($"Target entry {target.Id} has no senses to link.");
+
+        if (sourceSense.Translations.Any(x => x.TargetSenseId == targetSense.Id))
+            return;
+
+        dbContext.SenseTranslations.Add(new SenseTranslation
+        {
+            SourceSenseId = sourceSense.Id,
+            TargetSenseId = targetSense.Id,
+            Rank = 0,
+            CreatedAtUtc = now
+        });
+
+        dbContext.SenseTranslations.Add(new SenseTranslation
+        {
+            SourceSenseId = targetSense.Id,
+            TargetSenseId = sourceSense.Id,
+            Rank = 0,
+            CreatedAtUtc = now
+        });
     }
 
     private static DictionaryEntry MakeEntry(

--- a/apps/api/src/Langoose.Core/Services/EnrichmentProcessor.cs
+++ b/apps/api/src/Langoose.Core/Services/EnrichmentProcessor.cs
@@ -57,6 +57,9 @@ public sealed class EnrichmentProcessor(
                 .Include(x => x.Senses)
                     .ThenInclude(x => x.Translations).ThenInclude(x => x.TargetSense)
                     .ThenInclude(x => x.DictionaryEntry)
+                .Include(x => x.BaseEntry).ThenInclude(b => b!.Senses)
+                    .ThenInclude(s => s.Translations).ThenInclude(t => t.TargetSense)
+                    .ThenInclude(s => s.DictionaryEntry)
                 .Where(x => languages.Contains(x.Language) && texts.Contains(x.Text))
                 .ToArrayAsync(cancellationToken);
 
@@ -64,9 +67,7 @@ public sealed class EnrichmentProcessor(
                 .Where(x => lookupKeys.Contains(new EntryKey(x.Language, x.Text, x.PartOfSpeech)))
                 .ToDictionary(
                     x => new EntryKey(x.Language, x.Text, x.PartOfSpeech),
-                    x => x.BaseEntryId is null
-                        ? x
-                        : dbEntries.FirstOrDefault(y => y.Id == x.BaseEntryId) ?? x);
+                    x => x.BaseEntryId is null ? x : (x.BaseEntry ?? x));
         }
 
         // Step 2: resolve navigations from lookup, split into resolved vs needing enrichment

--- a/apps/api/src/Langoose.Core/Services/StudyService.cs
+++ b/apps/api/src/Langoose.Core/Services/StudyService.cs
@@ -62,15 +62,21 @@ public sealed class StudyService(AppDbContext dbContext) : IStudyService
             .First();
 
         var entry = await dbContext.DictionaryEntries
-            .Include(x => x.Translations)
+            .Include(x => x.Senses)
+                .ThenInclude(s => s.Translations.OrderBy(t => t.Rank))
+                .ThenInclude(t => t.TargetSense)
+                .ThenInclude(s => s.DictionaryEntry)
             .FirstAsync(x => x.Id == next.DictionaryEntryId, cancellationToken);
 
         var context = await dbContext.EntryContexts
             .Include(x => x.Translations)
             .FirstOrDefaultAsync(x => x.DictionaryEntryId == next.DictionaryEntryId, cancellationToken);
 
-        var translations = entry.Translations
-            .Select(x => x.Text)
+        var translations = entry.Senses
+            .OrderBy(s => s.SenseIndex)
+            .SelectMany(s => s.Translations)
+            .Select(t => t.TargetSense.DictionaryEntry.Text)
+            .Distinct()
             .ToList();
 
         var sentenceTranslation = context?.Translations

--- a/apps/api/src/Langoose.Data/AppDbContext.cs
+++ b/apps/api/src/Langoose.Data/AppDbContext.cs
@@ -6,12 +6,15 @@ namespace Langoose.Data;
 public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
 {
     public DbSet<DictionaryEntry> DictionaryEntries => Set<DictionaryEntry>();
+    public DbSet<Sense> Senses => Set<Sense>();
+    public DbSet<SenseTranslation> SenseTranslations => Set<SenseTranslation>();
     public DbSet<EntryContext> EntryContexts => Set<EntryContext>();
     public DbSet<UserDictionaryEntry> UserDictionaryEntries => Set<UserDictionaryEntry>();
     public DbSet<UserProgress> UserProgress => Set<UserProgress>();
     public DbSet<StudyEvent> StudyEvents => Set<StudyEvent>();
     public DbSet<ContentFlag> ContentFlags => Set<ContentFlag>();
     public DbSet<ImportRecord> ImportRecords => Set<ImportRecord>();
+    public DbSet<StagingEntry> StagingEntries => Set<StagingEntry>();
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         => optionsBuilder.UseSnakeCaseNamingConvention();

--- a/apps/api/src/Langoose.Data/Configurations/DictionaryEntryConfiguration.cs
+++ b/apps/api/src/Langoose.Data/Configurations/DictionaryEntryConfiguration.cs
@@ -21,12 +21,6 @@ public sealed class DictionaryEntryConfiguration : IEntityTypeConfiguration<Dict
             .IsRequired(false)
             .OnDelete(DeleteBehavior.Restrict);
 
-        builder.HasMany(x => x.Translations)
-            .WithMany()
-            .UsingEntity("dictionary_entries_translations",
-                x => x.HasOne(typeof(DictionaryEntry)).WithMany().HasForeignKey("target_id"),
-                x => x.HasOne(typeof(DictionaryEntry)).WithMany().HasForeignKey("source_id"));
-
         builder.HasIndex(x => new { x.Language, x.Text, x.PartOfSpeech });
         builder.HasIndex(x => x.BaseEntryId);
     }

--- a/apps/api/src/Langoose.Data/Configurations/SenseConfiguration.cs
+++ b/apps/api/src/Langoose.Data/Configurations/SenseConfiguration.cs
@@ -1,0 +1,21 @@
+using Langoose.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Langoose.Data.Configurations;
+
+public sealed class SenseConfiguration : IEntityTypeConfiguration<Sense>
+{
+    public void Configure(EntityTypeBuilder<Sense> builder)
+    {
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Gloss).HasMaxLength(500);
+
+        builder.HasOne(x => x.DictionaryEntry)
+            .WithMany(x => x.Senses)
+            .HasForeignKey(x => x.DictionaryEntryId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(x => new { x.DictionaryEntryId, x.SenseIndex }).IsUnique();
+    }
+}

--- a/apps/api/src/Langoose.Data/Configurations/SenseTranslationConfiguration.cs
+++ b/apps/api/src/Langoose.Data/Configurations/SenseTranslationConfiguration.cs
@@ -1,0 +1,25 @@
+using Langoose.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Langoose.Data.Configurations;
+
+public sealed class SenseTranslationConfiguration : IEntityTypeConfiguration<SenseTranslation>
+{
+    public void Configure(EntityTypeBuilder<SenseTranslation> builder)
+    {
+        builder.HasKey(x => new { x.SourceSenseId, x.TargetSenseId });
+
+        builder.HasOne(x => x.SourceSense)
+            .WithMany(x => x.Translations)
+            .HasForeignKey(x => x.SourceSenseId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.TargetSense)
+            .WithMany()
+            .HasForeignKey(x => x.TargetSenseId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(x => x.TargetSenseId);
+    }
+}

--- a/apps/api/src/Langoose.Data/Configurations/StagingEntryConfiguration.cs
+++ b/apps/api/src/Langoose.Data/Configurations/StagingEntryConfiguration.cs
@@ -1,0 +1,25 @@
+using Langoose.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Langoose.Data.Configurations;
+
+public sealed class StagingEntryConfiguration : IEntityTypeConfiguration<StagingEntry>
+{
+    public void Configure(EntityTypeBuilder<StagingEntry> builder)
+    {
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Source).HasConversion<string>().HasMaxLength(30);
+        builder.Property(x => x.Status).HasConversion<string>().HasMaxLength(30);
+        builder.Property(x => x.SourceRefId).HasMaxLength(200);
+        builder.Property(x => x.Language).HasMaxLength(10);
+        builder.Property(x => x.Text).HasMaxLength(300);
+        builder.Property(x => x.PartOfSpeech).HasMaxLength(50);
+        builder.Property(x => x.Payload).HasColumnType("jsonb");
+        builder.Property(x => x.StatusReason).HasMaxLength(500);
+        builder.Property(x => x.AiReasoning).HasMaxLength(2000);
+
+        builder.HasIndex(x => x.Status);
+        builder.HasIndex(x => new { x.Source, x.SourceRefId });
+    }
+}

--- a/apps/api/src/Langoose.Data/Migrations/20260425161624_InitialFoundation.Designer.cs
+++ b/apps/api/src/Langoose.Data/Migrations/20260425161624_InitialFoundation.Designer.cs
@@ -13,7 +13,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Langoose.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    [Migration("20260413051722_InitialFoundation")]
+    [Migration("20260425161624_InitialFoundation")]
     partial class InitialFoundation
     {
         /// <inheritdoc />
@@ -195,6 +195,165 @@ namespace Langoose.Data.Migrations
                         .HasDatabaseName("ix_import_records_user_id");
 
                     b.ToTable("import_records", (string)null);
+                });
+
+            modelBuilder.Entity("Langoose.Domain.Models.Sense", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasColumnName("id");
+
+                    b.Property<DateTimeOffset>("CreatedAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("created_at_utc");
+
+                    b.Property<Guid>("DictionaryEntryId")
+                        .HasColumnType("uuid")
+                        .HasColumnName("dictionary_entry_id");
+
+                    b.Property<string>("Gloss")
+                        .HasMaxLength(500)
+                        .HasColumnType("character varying(500)")
+                        .HasColumnName("gloss");
+
+                    b.Property<int>("SenseIndex")
+                        .HasColumnType("integer")
+                        .HasColumnName("sense_index");
+
+                    b.Property<DateTimeOffset>("UpdatedAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("updated_at_utc");
+
+                    b.HasKey("Id")
+                        .HasName("pk_senses");
+
+                    b.HasIndex("DictionaryEntryId", "SenseIndex")
+                        .IsUnique()
+                        .HasDatabaseName("ix_senses_dictionary_entry_id_sense_index");
+
+                    b.ToTable("senses", (string)null);
+                });
+
+            modelBuilder.Entity("Langoose.Domain.Models.SenseTranslation", b =>
+                {
+                    b.Property<Guid>("SourceSenseId")
+                        .HasColumnType("uuid")
+                        .HasColumnName("source_sense_id");
+
+                    b.Property<Guid>("TargetSenseId")
+                        .HasColumnType("uuid")
+                        .HasColumnName("target_sense_id");
+
+                    b.Property<DateTimeOffset>("CreatedAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("created_at_utc");
+
+                    b.Property<int>("Rank")
+                        .HasColumnType("integer")
+                        .HasColumnName("rank");
+
+                    b.HasKey("SourceSenseId", "TargetSenseId")
+                        .HasName("pk_sense_translations");
+
+                    b.HasIndex("TargetSenseId")
+                        .HasDatabaseName("ix_sense_translations_target_sense_id");
+
+                    b.ToTable("sense_translations", (string)null);
+                });
+
+            modelBuilder.Entity("Langoose.Domain.Models.StagingEntry", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasColumnName("id");
+
+                    b.Property<float?>("AiConfidence")
+                        .HasColumnType("real")
+                        .HasColumnName("ai_confidence");
+
+                    b.Property<string>("AiReasoning")
+                        .HasMaxLength(2000)
+                        .HasColumnType("character varying(2000)")
+                        .HasColumnName("ai_reasoning");
+
+                    b.Property<DateTimeOffset>("CreatedAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("created_at_utc");
+
+                    b.Property<string>("Language")
+                        .IsRequired()
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)")
+                        .HasColumnName("language");
+
+                    b.Property<string>("PartOfSpeech")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)")
+                        .HasColumnName("part_of_speech");
+
+                    b.Property<string>("Payload")
+                        .IsRequired()
+                        .HasColumnType("jsonb")
+                        .HasColumnName("payload");
+
+                    b.Property<Guid?>("PromotedEntryId")
+                        .HasColumnType("uuid")
+                        .HasColumnName("promoted_entry_id");
+
+                    b.Property<DateTimeOffset?>("ReviewedAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("reviewed_at_utc");
+
+                    b.Property<Guid?>("ReviewedByUserId")
+                        .HasColumnType("uuid")
+                        .HasColumnName("reviewed_by_user_id");
+
+                    b.Property<string>("Source")
+                        .IsRequired()
+                        .HasMaxLength(30)
+                        .HasColumnType("character varying(30)")
+                        .HasColumnName("source");
+
+                    b.Property<string>("SourceRefId")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)")
+                        .HasColumnName("source_ref_id");
+
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasMaxLength(30)
+                        .HasColumnType("character varying(30)")
+                        .HasColumnName("status");
+
+                    b.Property<string>("StatusReason")
+                        .HasMaxLength(500)
+                        .HasColumnType("character varying(500)")
+                        .HasColumnName("status_reason");
+
+                    b.Property<string>("Text")
+                        .IsRequired()
+                        .HasMaxLength(300)
+                        .HasColumnType("character varying(300)")
+                        .HasColumnName("text");
+
+                    b.Property<DateTimeOffset>("UpdatedAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("updated_at_utc");
+
+                    b.HasKey("Id")
+                        .HasName("pk_staging_entries");
+
+                    b.HasIndex("Status")
+                        .HasDatabaseName("ix_staging_entries_status");
+
+                    b.HasIndex("Source", "SourceRefId")
+                        .HasDatabaseName("ix_staging_entries_source_source_ref_id");
+
+                    b.ToTable("staging_entries", (string)null);
                 });
 
             modelBuilder.Entity("Langoose.Domain.Models.StudyEvent", b =>
@@ -408,25 +567,6 @@ namespace Langoose.Data.Migrations
                     b.ToTable("user_progress", (string)null);
                 });
 
-            modelBuilder.Entity("dictionary_entries_translations", b =>
-                {
-                    b.Property<Guid>("source_id")
-                        .HasColumnType("uuid")
-                        .HasColumnName("source_id");
-
-                    b.Property<Guid>("target_id")
-                        .HasColumnType("uuid")
-                        .HasColumnName("target_id");
-
-                    b.HasKey("source_id", "target_id")
-                        .HasName("pk_dictionary_entries_translations");
-
-                    b.HasIndex("target_id")
-                        .HasDatabaseName("ix_dictionary_entries_translations_target_id");
-
-                    b.ToTable("dictionary_entries_translations", (string)null);
-                });
-
             modelBuilder.Entity("entry_contexts_translations", b =>
                 {
                     b.Property<Guid>("source_id")
@@ -481,6 +621,39 @@ namespace Langoose.Data.Migrations
                     b.Navigation("DictionaryEntry");
                 });
 
+            modelBuilder.Entity("Langoose.Domain.Models.Sense", b =>
+                {
+                    b.HasOne("Langoose.Domain.Models.DictionaryEntry", "DictionaryEntry")
+                        .WithMany("Senses")
+                        .HasForeignKey("DictionaryEntryId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired()
+                        .HasConstraintName("fk_senses_dictionary_entries_dictionary_entry_id");
+
+                    b.Navigation("DictionaryEntry");
+                });
+
+            modelBuilder.Entity("Langoose.Domain.Models.SenseTranslation", b =>
+                {
+                    b.HasOne("Langoose.Domain.Models.Sense", "SourceSense")
+                        .WithMany("Translations")
+                        .HasForeignKey("SourceSenseId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired()
+                        .HasConstraintName("fk_sense_translations_senses_source_sense_id");
+
+                    b.HasOne("Langoose.Domain.Models.Sense", "TargetSense")
+                        .WithMany()
+                        .HasForeignKey("TargetSenseId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired()
+                        .HasConstraintName("fk_sense_translations_senses_target_sense_id");
+
+                    b.Navigation("SourceSense");
+
+                    b.Navigation("TargetSense");
+                });
+
             modelBuilder.Entity("Langoose.Domain.Models.StudyEvent", b =>
                 {
                     b.HasOne("Langoose.Domain.Models.DictionaryEntry", "DictionaryEntry")
@@ -532,23 +705,6 @@ namespace Langoose.Data.Migrations
                     b.Navigation("DictionaryEntry");
                 });
 
-            modelBuilder.Entity("dictionary_entries_translations", b =>
-                {
-                    b.HasOne("Langoose.Domain.Models.DictionaryEntry", null)
-                        .WithMany()
-                        .HasForeignKey("source_id")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_dictionary_entries_translations_dictionary_entries_source_id");
-
-                    b.HasOne("Langoose.Domain.Models.DictionaryEntry", null)
-                        .WithMany()
-                        .HasForeignKey("target_id")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_dictionary_entries_translations_dictionary_entries_target_id");
-                });
-
             modelBuilder.Entity("entry_contexts_translations", b =>
                 {
                     b.HasOne("Langoose.Domain.Models.EntryContext", null)
@@ -571,6 +727,13 @@ namespace Langoose.Data.Migrations
                     b.Navigation("Contexts");
 
                     b.Navigation("DerivedForms");
+
+                    b.Navigation("Senses");
+                });
+
+            modelBuilder.Entity("Langoose.Domain.Models.Sense", b =>
+                {
+                    b.Navigation("Translations");
                 });
 #pragma warning restore 612, 618
         }

--- a/apps/api/src/Langoose.Data/Migrations/20260425161624_InitialFoundation.cs
+++ b/apps/api/src/Langoose.Data/Migrations/20260425161624_InitialFoundation.cs
@@ -54,6 +54,32 @@ namespace Langoose.Data.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "staging_entries",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    source = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    source_ref_id = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    language = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    text = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                    part_of_speech = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    payload = table.Column<string>(type: "jsonb", nullable: false),
+                    status = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    status_reason = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    ai_confidence = table.Column<float>(type: "real", nullable: true),
+                    ai_reasoning = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    reviewed_by_user_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    reviewed_at_utc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    promoted_entry_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    created_at_utc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at_utc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_staging_entries", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "content_flags",
                 columns: table => new
                 {
@@ -76,30 +102,6 @@ namespace Langoose.Data.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: "dictionary_entries_translations",
-                columns: table => new
-                {
-                    source_id = table.Column<Guid>(type: "uuid", nullable: false),
-                    target_id = table.Column<Guid>(type: "uuid", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("pk_dictionary_entries_translations", x => new { x.source_id, x.target_id });
-                    table.ForeignKey(
-                        name: "fk_dictionary_entries_translations_dictionary_entries_source_id",
-                        column: x => x.source_id,
-                        principalTable: "dictionary_entries",
-                        principalColumn: "id",
-                        onDelete: ReferentialAction.Cascade);
-                    table.ForeignKey(
-                        name: "fk_dictionary_entries_translations_dictionary_entries_target_id",
-                        column: x => x.target_id,
-                        principalTable: "dictionary_entries",
-                        principalColumn: "id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateTable(
                 name: "entry_contexts",
                 columns: table => new
                 {
@@ -115,6 +117,28 @@ namespace Langoose.Data.Migrations
                     table.PrimaryKey("pk_entry_contexts", x => x.id);
                     table.ForeignKey(
                         name: "fk_entry_contexts_dictionary_entries_dictionary_entry_id",
+                        column: x => x.dictionary_entry_id,
+                        principalTable: "dictionary_entries",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "senses",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    dictionary_entry_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    sense_index = table.Column<int>(type: "integer", nullable: false),
+                    gloss = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    created_at_utc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at_utc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_senses", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_senses_dictionary_entries_dictionary_entry_id",
                         column: x => x.dictionary_entry_id,
                         principalTable: "dictionary_entries",
                         principalColumn: "id",
@@ -240,6 +264,32 @@ namespace Langoose.Data.Migrations
                         onDelete: ReferentialAction.SetNull);
                 });
 
+            migrationBuilder.CreateTable(
+                name: "sense_translations",
+                columns: table => new
+                {
+                    source_sense_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    target_sense_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    rank = table.Column<int>(type: "integer", nullable: false),
+                    created_at_utc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_sense_translations", x => new { x.source_sense_id, x.target_sense_id });
+                    table.ForeignKey(
+                        name: "fk_sense_translations_senses_source_sense_id",
+                        column: x => x.source_sense_id,
+                        principalTable: "senses",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_sense_translations_senses_target_sense_id",
+                        column: x => x.target_sense_id,
+                        principalTable: "senses",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
             migrationBuilder.CreateIndex(
                 name: "ix_content_flags_dictionary_entry_id",
                 table: "content_flags",
@@ -256,11 +306,6 @@ namespace Langoose.Data.Migrations
                 columns: new[] { "language", "text", "part_of_speech" });
 
             migrationBuilder.CreateIndex(
-                name: "ix_dictionary_entries_translations_target_id",
-                table: "dictionary_entries_translations",
-                column: "target_id");
-
-            migrationBuilder.CreateIndex(
                 name: "ix_entry_contexts_dictionary_entry_id",
                 table: "entry_contexts",
                 column: "dictionary_entry_id");
@@ -274,6 +319,27 @@ namespace Langoose.Data.Migrations
                 name: "ix_import_records_user_id",
                 table: "import_records",
                 column: "user_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_sense_translations_target_sense_id",
+                table: "sense_translations",
+                column: "target_sense_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_senses_dictionary_entry_id_sense_index",
+                table: "senses",
+                columns: new[] { "dictionary_entry_id", "sense_index" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_staging_entries_source_source_ref_id",
+                table: "staging_entries",
+                columns: new[] { "source", "source_ref_id" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_staging_entries_status",
+                table: "staging_entries",
+                column: "status");
 
             migrationBuilder.CreateIndex(
                 name: "ix_study_events_dictionary_entry_id",
@@ -334,13 +400,16 @@ namespace Langoose.Data.Migrations
                 name: "content_flags");
 
             migrationBuilder.DropTable(
-                name: "dictionary_entries_translations");
-
-            migrationBuilder.DropTable(
                 name: "entry_contexts_translations");
 
             migrationBuilder.DropTable(
                 name: "import_records");
+
+            migrationBuilder.DropTable(
+                name: "sense_translations");
+
+            migrationBuilder.DropTable(
+                name: "staging_entries");
 
             migrationBuilder.DropTable(
                 name: "study_events");
@@ -350,6 +419,9 @@ namespace Langoose.Data.Migrations
 
             migrationBuilder.DropTable(
                 name: "user_progress");
+
+            migrationBuilder.DropTable(
+                name: "senses");
 
             migrationBuilder.DropTable(
                 name: "entry_contexts");

--- a/apps/api/src/Langoose.Data/Migrations/AppDbContextModelSnapshot.cs
+++ b/apps/api/src/Langoose.Data/Migrations/AppDbContextModelSnapshot.cs
@@ -194,6 +194,165 @@ namespace Langoose.Data.Migrations
                     b.ToTable("import_records", (string)null);
                 });
 
+            modelBuilder.Entity("Langoose.Domain.Models.Sense", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasColumnName("id");
+
+                    b.Property<DateTimeOffset>("CreatedAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("created_at_utc");
+
+                    b.Property<Guid>("DictionaryEntryId")
+                        .HasColumnType("uuid")
+                        .HasColumnName("dictionary_entry_id");
+
+                    b.Property<string>("Gloss")
+                        .HasMaxLength(500)
+                        .HasColumnType("character varying(500)")
+                        .HasColumnName("gloss");
+
+                    b.Property<int>("SenseIndex")
+                        .HasColumnType("integer")
+                        .HasColumnName("sense_index");
+
+                    b.Property<DateTimeOffset>("UpdatedAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("updated_at_utc");
+
+                    b.HasKey("Id")
+                        .HasName("pk_senses");
+
+                    b.HasIndex("DictionaryEntryId", "SenseIndex")
+                        .IsUnique()
+                        .HasDatabaseName("ix_senses_dictionary_entry_id_sense_index");
+
+                    b.ToTable("senses", (string)null);
+                });
+
+            modelBuilder.Entity("Langoose.Domain.Models.SenseTranslation", b =>
+                {
+                    b.Property<Guid>("SourceSenseId")
+                        .HasColumnType("uuid")
+                        .HasColumnName("source_sense_id");
+
+                    b.Property<Guid>("TargetSenseId")
+                        .HasColumnType("uuid")
+                        .HasColumnName("target_sense_id");
+
+                    b.Property<DateTimeOffset>("CreatedAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("created_at_utc");
+
+                    b.Property<int>("Rank")
+                        .HasColumnType("integer")
+                        .HasColumnName("rank");
+
+                    b.HasKey("SourceSenseId", "TargetSenseId")
+                        .HasName("pk_sense_translations");
+
+                    b.HasIndex("TargetSenseId")
+                        .HasDatabaseName("ix_sense_translations_target_sense_id");
+
+                    b.ToTable("sense_translations", (string)null);
+                });
+
+            modelBuilder.Entity("Langoose.Domain.Models.StagingEntry", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasColumnName("id");
+
+                    b.Property<float?>("AiConfidence")
+                        .HasColumnType("real")
+                        .HasColumnName("ai_confidence");
+
+                    b.Property<string>("AiReasoning")
+                        .HasMaxLength(2000)
+                        .HasColumnType("character varying(2000)")
+                        .HasColumnName("ai_reasoning");
+
+                    b.Property<DateTimeOffset>("CreatedAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("created_at_utc");
+
+                    b.Property<string>("Language")
+                        .IsRequired()
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)")
+                        .HasColumnName("language");
+
+                    b.Property<string>("PartOfSpeech")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)")
+                        .HasColumnName("part_of_speech");
+
+                    b.Property<string>("Payload")
+                        .IsRequired()
+                        .HasColumnType("jsonb")
+                        .HasColumnName("payload");
+
+                    b.Property<Guid?>("PromotedEntryId")
+                        .HasColumnType("uuid")
+                        .HasColumnName("promoted_entry_id");
+
+                    b.Property<DateTimeOffset?>("ReviewedAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("reviewed_at_utc");
+
+                    b.Property<Guid?>("ReviewedByUserId")
+                        .HasColumnType("uuid")
+                        .HasColumnName("reviewed_by_user_id");
+
+                    b.Property<string>("Source")
+                        .IsRequired()
+                        .HasMaxLength(30)
+                        .HasColumnType("character varying(30)")
+                        .HasColumnName("source");
+
+                    b.Property<string>("SourceRefId")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)")
+                        .HasColumnName("source_ref_id");
+
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasMaxLength(30)
+                        .HasColumnType("character varying(30)")
+                        .HasColumnName("status");
+
+                    b.Property<string>("StatusReason")
+                        .HasMaxLength(500)
+                        .HasColumnType("character varying(500)")
+                        .HasColumnName("status_reason");
+
+                    b.Property<string>("Text")
+                        .IsRequired()
+                        .HasMaxLength(300)
+                        .HasColumnType("character varying(300)")
+                        .HasColumnName("text");
+
+                    b.Property<DateTimeOffset>("UpdatedAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("updated_at_utc");
+
+                    b.HasKey("Id")
+                        .HasName("pk_staging_entries");
+
+                    b.HasIndex("Status")
+                        .HasDatabaseName("ix_staging_entries_status");
+
+                    b.HasIndex("Source", "SourceRefId")
+                        .HasDatabaseName("ix_staging_entries_source_source_ref_id");
+
+                    b.ToTable("staging_entries", (string)null);
+                });
+
             modelBuilder.Entity("Langoose.Domain.Models.StudyEvent", b =>
                 {
                     b.Property<Guid>("Id")
@@ -405,25 +564,6 @@ namespace Langoose.Data.Migrations
                     b.ToTable("user_progress", (string)null);
                 });
 
-            modelBuilder.Entity("dictionary_entries_translations", b =>
-                {
-                    b.Property<Guid>("source_id")
-                        .HasColumnType("uuid")
-                        .HasColumnName("source_id");
-
-                    b.Property<Guid>("target_id")
-                        .HasColumnType("uuid")
-                        .HasColumnName("target_id");
-
-                    b.HasKey("source_id", "target_id")
-                        .HasName("pk_dictionary_entries_translations");
-
-                    b.HasIndex("target_id")
-                        .HasDatabaseName("ix_dictionary_entries_translations_target_id");
-
-                    b.ToTable("dictionary_entries_translations", (string)null);
-                });
-
             modelBuilder.Entity("entry_contexts_translations", b =>
                 {
                     b.Property<Guid>("source_id")
@@ -478,6 +618,39 @@ namespace Langoose.Data.Migrations
                     b.Navigation("DictionaryEntry");
                 });
 
+            modelBuilder.Entity("Langoose.Domain.Models.Sense", b =>
+                {
+                    b.HasOne("Langoose.Domain.Models.DictionaryEntry", "DictionaryEntry")
+                        .WithMany("Senses")
+                        .HasForeignKey("DictionaryEntryId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired()
+                        .HasConstraintName("fk_senses_dictionary_entries_dictionary_entry_id");
+
+                    b.Navigation("DictionaryEntry");
+                });
+
+            modelBuilder.Entity("Langoose.Domain.Models.SenseTranslation", b =>
+                {
+                    b.HasOne("Langoose.Domain.Models.Sense", "SourceSense")
+                        .WithMany("Translations")
+                        .HasForeignKey("SourceSenseId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired()
+                        .HasConstraintName("fk_sense_translations_senses_source_sense_id");
+
+                    b.HasOne("Langoose.Domain.Models.Sense", "TargetSense")
+                        .WithMany()
+                        .HasForeignKey("TargetSenseId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired()
+                        .HasConstraintName("fk_sense_translations_senses_target_sense_id");
+
+                    b.Navigation("SourceSense");
+
+                    b.Navigation("TargetSense");
+                });
+
             modelBuilder.Entity("Langoose.Domain.Models.StudyEvent", b =>
                 {
                     b.HasOne("Langoose.Domain.Models.DictionaryEntry", "DictionaryEntry")
@@ -529,23 +702,6 @@ namespace Langoose.Data.Migrations
                     b.Navigation("DictionaryEntry");
                 });
 
-            modelBuilder.Entity("dictionary_entries_translations", b =>
-                {
-                    b.HasOne("Langoose.Domain.Models.DictionaryEntry", null)
-                        .WithMany()
-                        .HasForeignKey("source_id")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_dictionary_entries_translations_dictionary_entries_source_id");
-
-                    b.HasOne("Langoose.Domain.Models.DictionaryEntry", null)
-                        .WithMany()
-                        .HasForeignKey("target_id")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_dictionary_entries_translations_dictionary_entries_target_id");
-                });
-
             modelBuilder.Entity("entry_contexts_translations", b =>
                 {
                     b.HasOne("Langoose.Domain.Models.EntryContext", null)
@@ -568,6 +724,13 @@ namespace Langoose.Data.Migrations
                     b.Navigation("Contexts");
 
                     b.Navigation("DerivedForms");
+
+                    b.Navigation("Senses");
+                });
+
+            modelBuilder.Entity("Langoose.Domain.Models.Sense", b =>
+                {
+                    b.Navigation("Translations");
                 });
 #pragma warning restore 612, 618
         }

--- a/apps/api/src/Langoose.Data/Seeding/DatabaseSeeder.cs
+++ b/apps/api/src/Langoose.Data/Seeding/DatabaseSeeder.cs
@@ -14,6 +14,8 @@ public sealed class DatabaseSeeder(AppDbContext dbContext)
         var batch = SeedDataLoader.LoadBaseItems();
 
         dbContext.DictionaryEntries.AddRange(batch.Entries);
+        dbContext.Senses.AddRange(batch.Senses);
+        dbContext.SenseTranslations.AddRange(batch.SenseTranslations);
         dbContext.EntryContexts.AddRange(batch.Contexts);
 
         await dbContext.SaveChangesAsync(cancellationToken);

--- a/apps/api/src/Langoose.Data/Seeding/SeedDataLoader.cs
+++ b/apps/api/src/Langoose.Data/Seeding/SeedDataLoader.cs
@@ -12,6 +12,8 @@ public static class SeedDataLoader
             ?? throw new InvalidOperationException("Seed payload could not be deserialized.");
 
         var entries = new List<DictionaryEntry>();
+        var senses = new List<Sense>();
+        var senseTranslations = new List<SenseTranslation>();
         var contexts = new List<EntryContext>();
 
         var now = DateTimeOffset.UtcNow;
@@ -42,11 +44,45 @@ public static class SeedDataLoader
                 UpdatedAtUtc = now
             };
 
-            enEntry.Translations.Add(ruEntry);
-            ruEntry.Translations.Add(enEntry);
-
             entries.Add(enEntry);
             entries.Add(ruEntry);
+
+            var enSense = new Sense
+            {
+                Id = Guid.CreateVersion7(),
+                DictionaryEntryId = enEntry.Id,
+                SenseIndex = 0,
+                CreatedAtUtc = now,
+                UpdatedAtUtc = now
+            };
+
+            var ruSense = new Sense
+            {
+                Id = Guid.CreateVersion7(),
+                DictionaryEntryId = ruEntry.Id,
+                SenseIndex = 0,
+                CreatedAtUtc = now,
+                UpdatedAtUtc = now
+            };
+
+            senses.Add(enSense);
+            senses.Add(ruSense);
+
+            senseTranslations.Add(new SenseTranslation
+            {
+                SourceSenseId = enSense.Id,
+                TargetSenseId = ruSense.Id,
+                Rank = 0,
+                CreatedAtUtc = now
+            });
+
+            senseTranslations.Add(new SenseTranslation
+            {
+                SourceSenseId = ruSense.Id,
+                TargetSenseId = enSense.Id,
+                Rank = 0,
+                CreatedAtUtc = now
+            });
 
             var sentenceText = item.Cloze.Replace("____", item.English, StringComparison.Ordinal);
             var enContext = new EntryContext
@@ -76,7 +112,7 @@ public static class SeedDataLoader
             contexts.Add(ruContext);
         }
 
-        return new SeedBatch(entries, contexts);
+        return new SeedBatch(entries, senses, senseTranslations, contexts);
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
@@ -109,4 +145,6 @@ public static class SeedDataLoader
 
 public sealed record SeedBatch(
     IReadOnlyList<DictionaryEntry> Entries,
+    IReadOnlyList<Sense> Senses,
+    IReadOnlyList<SenseTranslation> SenseTranslations,
     IReadOnlyList<EntryContext> Contexts);

--- a/apps/api/src/Langoose.Domain/Enums/EntrySource.cs
+++ b/apps/api/src/Langoose.Domain/Enums/EntrySource.cs
@@ -1,0 +1,9 @@
+namespace Langoose.Domain.Enums;
+
+public enum EntrySource
+{
+    Wiktionary,
+    Manual,
+    Import,
+    UserSuggest
+}

--- a/apps/api/src/Langoose.Domain/Enums/StagingStatus.cs
+++ b/apps/api/src/Langoose.Domain/Enums/StagingStatus.cs
@@ -1,0 +1,13 @@
+namespace Langoose.Domain.Enums;
+
+public enum StagingStatus
+{
+    Imported,
+    HeuristicAccepted,
+    HeuristicRejected,
+    AiAccepted,
+    AiRejected,
+    Approved,
+    Rejected,
+    Promoted
+}

--- a/apps/api/src/Langoose.Domain/Models/DictionaryEntry.cs
+++ b/apps/api/src/Langoose.Domain/Models/DictionaryEntry.cs
@@ -11,10 +11,10 @@ public sealed class DictionaryEntry
     public string? Difficulty { get; set; }
     public required bool IsPublic { get; set; }
     public required DateTimeOffset CreatedAtUtc { get; init; }
-    public DateTimeOffset UpdatedAtUtc { get; set; }
+    public required DateTimeOffset UpdatedAtUtc { get; set; }
 
     public DictionaryEntry? BaseEntry { get; set; }
     public ICollection<DictionaryEntry> DerivedForms { get; set; } = [];
     public ICollection<EntryContext> Contexts { get; set; } = [];
-    public ICollection<DictionaryEntry> Translations { get; set; } = [];
+    public ICollection<Sense> Senses { get; set; } = [];
 }

--- a/apps/api/src/Langoose.Domain/Models/Sense.cs
+++ b/apps/api/src/Langoose.Domain/Models/Sense.cs
@@ -1,0 +1,14 @@
+namespace Langoose.Domain.Models;
+
+public sealed class Sense
+{
+    public required Guid Id { get; init; }
+    public required Guid DictionaryEntryId { get; set; }
+    public required int SenseIndex { get; set; }
+    public string? Gloss { get; set; }
+    public required DateTimeOffset CreatedAtUtc { get; init; }
+    public required DateTimeOffset UpdatedAtUtc { get; set; }
+
+    public DictionaryEntry DictionaryEntry { get; set; } = null!;
+    public ICollection<SenseTranslation> Translations { get; set; } = [];
+}

--- a/apps/api/src/Langoose.Domain/Models/SenseTranslation.cs
+++ b/apps/api/src/Langoose.Domain/Models/SenseTranslation.cs
@@ -1,0 +1,12 @@
+namespace Langoose.Domain.Models;
+
+public sealed class SenseTranslation
+{
+    public required Guid SourceSenseId { get; set; }
+    public required Guid TargetSenseId { get; set; }
+    public required int Rank { get; set; }
+    public required DateTimeOffset CreatedAtUtc { get; init; }
+
+    public Sense SourceSense { get; set; } = null!;
+    public Sense TargetSense { get; set; } = null!;
+}

--- a/apps/api/src/Langoose.Domain/Models/StagingEntry.cs
+++ b/apps/api/src/Langoose.Domain/Models/StagingEntry.cs
@@ -1,0 +1,23 @@
+using Langoose.Domain.Enums;
+
+namespace Langoose.Domain.Models;
+
+public sealed class StagingEntry
+{
+    public required Guid Id { get; init; }
+    public required EntrySource Source { get; set; }
+    public required string SourceRefId { get; set; }
+    public required string Language { get; set; }
+    public required string Text { get; set; }
+    public required string PartOfSpeech { get; set; }
+    public required string Payload { get; set; }
+    public required StagingStatus Status { get; set; }
+    public string? StatusReason { get; set; }
+    public float? AiConfidence { get; set; }
+    public string? AiReasoning { get; set; }
+    public Guid? ReviewedByUserId { get; set; }
+    public DateTimeOffset? ReviewedAtUtc { get; set; }
+    public Guid? PromotedEntryId { get; set; }
+    public required DateTimeOffset CreatedAtUtc { get; init; }
+    public required DateTimeOffset UpdatedAtUtc { get; set; }
+}

--- a/apps/api/src/Langoose.Domain/Models/UserDictionaryEntry.cs
+++ b/apps/api/src/Langoose.Domain/Models/UserDictionaryEntry.cs
@@ -19,7 +19,7 @@ public sealed class UserDictionaryEntry
     public string? Notes { get; set; }
     public List<string> Tags { get; set; } = [];
     public required DateTimeOffset CreatedAtUtc { get; init; }
-    public DateTimeOffset UpdatedAtUtc { get; set; }
+    public required DateTimeOffset UpdatedAtUtc { get; set; }
 
     public DictionaryEntry? SourceEntry { get; set; }
     public DictionaryEntry? TargetEntry { get; set; }

--- a/apps/api/src/Langoose.Domain/Models/UserProgress.cs
+++ b/apps/api/src/Langoose.Domain/Models/UserProgress.cs
@@ -12,7 +12,7 @@ public sealed class UserProgress
     public double? Stability { get; set; }
     public double? Difficulty { get; set; }
     public required DateTimeOffset CreatedAtUtc { get; init; }
-    public DateTimeOffset UpdatedAtUtc { get; set; }
+    public required DateTimeOffset UpdatedAtUtc { get; set; }
 
     public DictionaryEntry DictionaryEntry { get; set; } = null!;
 }

--- a/apps/api/tests/Langoose.Api.IntegrationTests/Services/DictionaryServiceIntegrationTests.cs
+++ b/apps/api/tests/Langoose.Api.IntegrationTests/Services/DictionaryServiceIntegrationTests.cs
@@ -25,8 +25,12 @@ public sealed class DictionaryServiceIntegrationTests
         Assert.Contains(batch.Entries, x => x.Language == "en" && x.Text == "book");
         Assert.Contains(batch.Entries, x => x.Language == "ru" && x.Text == "\u043A\u043D\u0438\u0433\u0430");
 
+        Assert.True(batch.Senses.Count > 0);
+        Assert.True(batch.SenseTranslations.Count > 0);
+
         var enBook = batch.Entries.First(x => x.Language == "en" && x.Text == "book");
-        Assert.NotEmpty(enBook.Translations);
+        var enBookSense = batch.Senses.First(s => s.DictionaryEntryId == enBook.Id);
+        Assert.Contains(batch.SenseTranslations, t => t.SourceSenseId == enBookSense.Id);
     }
 
     [Fact]

--- a/apps/api/tests/Langoose.Core.UnitTests/Services/EnrichmentProcessorTests.cs
+++ b/apps/api/tests/Langoose.Core.UnitTests/Services/EnrichmentProcessorTests.cs
@@ -51,7 +51,7 @@ public sealed class EnrichmentProcessorTests
     }
 
     [Fact]
-    public async Task ProcessPendingBatchAsync_LinksBaseFormsViaManyToMany()
+    public async Task ProcessPendingBatchAsync_LinksBaseFormsViaSenseTranslations()
     {
         var (processor, db) = CreateProcessor();
         db.UserDictionaryEntries.Add(CreatePendingItem("book", "книга"));
@@ -62,12 +62,17 @@ public sealed class EnrichmentProcessorTests
             DefaultBatchSize, DefaultMaxRetries, CancellationToken.None);
 
         var sourceBase = await db.DictionaryEntries
-            .Include(x => x.Translations)
+            .Include(x => x.Senses).ThenInclude(s => s.Translations)
             .FirstAsync(x => x.Language == "en" && x.BaseEntryId == null);
         var targetBase = await db.DictionaryEntries
+            .Include(x => x.Senses).ThenInclude(s => s.Translations)
             .FirstAsync(x => x.Language == "ru" && x.BaseEntryId == null);
 
-        sourceBase.Translations.Should().Contain(x => x.Id == targetBase.Id);
+        var targetSenseIds = targetBase.Senses.Select(s => s.Id).ToHashSet();
+        sourceBase.Senses.Should().NotBeEmpty();
+        sourceBase.Senses
+            .SelectMany(s => s.Translations)
+            .Should().Contain(t => targetSenseIds.Contains(t.TargetSenseId));
     }
 
     [Fact]
@@ -277,20 +282,43 @@ public sealed class EnrichmentProcessorTests
         AppDbContext db, string sourceText, string sourceLang,
         string targetText, string targetLang)
     {
+        var now = DateTimeOffset.UtcNow;
         var sourceEntry = new DictionaryEntry
         {
             Id = Guid.CreateVersion7(), Language = sourceLang, Text = sourceText,
             PartOfSpeech = "noun", IsPublic = true,
-            CreatedAtUtc = DateTimeOffset.UtcNow, UpdatedAtUtc = DateTimeOffset.UtcNow
+            CreatedAtUtc = now, UpdatedAtUtc = now
         };
         var targetEntry = new DictionaryEntry
         {
             Id = Guid.CreateVersion7(), Language = targetLang, Text = targetText,
             PartOfSpeech = "noun", IsPublic = true,
-            CreatedAtUtc = DateTimeOffset.UtcNow, UpdatedAtUtc = DateTimeOffset.UtcNow
+            CreatedAtUtc = now, UpdatedAtUtc = now
+        };
+        var sourceSense = new Sense
+        {
+            Id = Guid.CreateVersion7(), DictionaryEntryId = sourceEntry.Id,
+            SenseIndex = 0,
+            CreatedAtUtc = now, UpdatedAtUtc = now
+        };
+        var targetSense = new Sense
+        {
+            Id = Guid.CreateVersion7(), DictionaryEntryId = targetEntry.Id,
+            SenseIndex = 0,
+            CreatedAtUtc = now, UpdatedAtUtc = now
         };
         db.DictionaryEntries.AddRange(sourceEntry, targetEntry);
-        sourceEntry.Translations.Add(targetEntry);
-        targetEntry.Translations.Add(sourceEntry);
+        db.Senses.AddRange(sourceSense, targetSense);
+        db.SenseTranslations.AddRange(
+            new SenseTranslation
+            {
+                SourceSenseId = sourceSense.Id, TargetSenseId = targetSense.Id,
+                Rank = 0, CreatedAtUtc = now
+            },
+            new SenseTranslation
+            {
+                SourceSenseId = targetSense.Id, TargetSenseId = sourceSense.Id,
+                Rank = 0, CreatedAtUtc = now
+            });
     }
 }

--- a/apps/api/tests/Langoose.Core.UnitTests/Services/EnrichmentProcessorTests.cs
+++ b/apps/api/tests/Langoose.Core.UnitTests/Services/EnrichmentProcessorTests.cs
@@ -114,6 +114,29 @@ public sealed class EnrichmentProcessorTests
     }
 
     [Fact]
+    public async Task ProcessPendingBatchAsync_WhenUserInputMatchesDerivedForm_ResolvesToBaseEntry()
+    {
+        var (processor, db) = CreateProcessor();
+        var (enBase, _, ruBase) = SeedExistingTranslationWithDerivedForm(
+            db, baseText: "book", derivedText: "books", sourceLang: "en",
+            targetText: "книга", targetLang: "ru");
+        db.UserDictionaryEntries.Add(CreatePendingItem("books", "книга"));
+
+        await db.SaveChangesAsync();
+        var entriesBefore = await db.DictionaryEntries.CountAsync();
+
+        await processor.ProcessPendingBatchAsync(
+            DefaultBatchSize, DefaultMaxRetries, CancellationToken.None);
+
+        (await db.DictionaryEntries.CountAsync()).Should().Be(entriesBefore);
+
+        var updated = await db.UserDictionaryEntries.SingleAsync();
+        updated.EnrichmentStatus.Should().Be(EnrichmentStatus.Enriched);
+        updated.SourceEntryId.Should().Be(enBase.Id, "lookup must walk derived → base");
+        updated.TargetEntryId.Should().Be(ruBase.Id);
+    }
+
+    [Fact]
     public async Task ProcessPendingBatchAsync_SkipsItemsWithFutureEnrichmentNotBefore()
     {
         var (processor, db) = CreateProcessor();
@@ -320,5 +343,59 @@ public sealed class EnrichmentProcessorTests
                 SourceSenseId = targetSense.Id, TargetSenseId = sourceSense.Id,
                 Rank = 0, CreatedAtUtc = now
             });
+    }
+
+    private static (DictionaryEntry SourceBase, DictionaryEntry SourceDerived, DictionaryEntry TargetBase)
+        SeedExistingTranslationWithDerivedForm(
+            AppDbContext db, string baseText, string derivedText, string sourceLang,
+            string targetText, string targetLang)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var sourceBase = new DictionaryEntry
+        {
+            Id = Guid.CreateVersion7(), Language = sourceLang, Text = baseText,
+            PartOfSpeech = "noun", IsPublic = true,
+            CreatedAtUtc = now, UpdatedAtUtc = now
+        };
+        var sourceDerived = new DictionaryEntry
+        {
+            Id = Guid.CreateVersion7(), Language = sourceLang, Text = derivedText,
+            BaseEntryId = sourceBase.Id,
+            PartOfSpeech = "noun", IsPublic = true,
+            CreatedAtUtc = now, UpdatedAtUtc = now
+        };
+        var targetBase = new DictionaryEntry
+        {
+            Id = Guid.CreateVersion7(), Language = targetLang, Text = targetText,
+            PartOfSpeech = "noun", IsPublic = true,
+            CreatedAtUtc = now, UpdatedAtUtc = now
+        };
+        var sourceBaseSense = new Sense
+        {
+            Id = Guid.CreateVersion7(), DictionaryEntryId = sourceBase.Id,
+            SenseIndex = 0,
+            CreatedAtUtc = now, UpdatedAtUtc = now
+        };
+        var targetBaseSense = new Sense
+        {
+            Id = Guid.CreateVersion7(), DictionaryEntryId = targetBase.Id,
+            SenseIndex = 0,
+            CreatedAtUtc = now, UpdatedAtUtc = now
+        };
+        db.DictionaryEntries.AddRange(sourceBase, sourceDerived, targetBase);
+        db.Senses.AddRange(sourceBaseSense, targetBaseSense);
+        db.SenseTranslations.AddRange(
+            new SenseTranslation
+            {
+                SourceSenseId = sourceBaseSense.Id, TargetSenseId = targetBaseSense.Id,
+                Rank = 0, CreatedAtUtc = now
+            },
+            new SenseTranslation
+            {
+                SourceSenseId = targetBaseSense.Id, TargetSenseId = sourceBaseSense.Id,
+                Rank = 0, CreatedAtUtc = now
+            });
+
+        return (sourceBase, sourceDerived, targetBase);
     }
 }

--- a/docs/agent/dictionary-schema-design.md
+++ b/docs/agent/dictionary-schema-design.md
@@ -101,7 +101,7 @@ sense_translations
   source_sense_id  Guid
   target_sense_id  Guid
   rank             int       -- 0-based; lower wins for "primary translation"
-  source           text      -- enum: 'wiktionary', 'manual', 'import'
+  created_at_utc   timestamptz
 
 primary key (source_sense_id, target_sense_id)
 ```

--- a/docs/agent/dictionary-schema-design.md
+++ b/docs/agent/dictionary-schema-design.md
@@ -152,7 +152,7 @@ before promotion.
 ```
 staging_entries
   Id              Guid (v7)
-  Source          enum   ('wiktionary', 'wordfreq', 'csv-import', 'user-suggest')
+  Source          enum   (EntrySource: 'Wiktionary', 'Manual', 'Import', 'UserSuggest')
   SourceRefId     text   -- e.g. corpus row id, csv row #, originating user id
   Language        text
   Text            text
@@ -168,9 +168,18 @@ staging_entries
   CreatedAtUtc    timestamptz
   UpdatedAtUtc    timestamptz
 
-index (Status)
-index (Source, Status)
+index (Status)                    -- worker polling by status
+index (Source, SourceRefId)       -- dedup at import; non-unique, app enforces no-duplicate-insert
 ```
+
+`EntrySource` is the same enum used elsewhere in the app's content
+provenance vocabulary (currently used only by `StagingEntry.Source`).
+`'Wiktionary'` covers the bulk corpus import path, `'Import'` covers
+CSV bulk imports, `'UserSuggest'` covers user-driven suggestions
+flowing into the public review queue, `'Manual'` covers admin-entered
+candidates. Adding a separate frequency-only source like wordfreq is
+unnecessary — wordfreq feeds into translation `Rank` on already-existing
+candidates rather than producing its own staging rows.
 
 `Payload` is the **bundle shape** for one candidate dictionary entry —
 the entry header plus all of its senses and their cross-language

--- a/docs/agent/dictionary-schema-design.md
+++ b/docs/agent/dictionary-schema-design.md
@@ -1,0 +1,388 @@
+# Dictionary Schema Design
+
+Status: **proposed** (2026-04-25). Spec for the schema rework that unblocks
+base-dictionary materialization (#57), the corpus-backed enrichment provider
+(#92), and context generation (#91). When the implementation lands the status
+moves to **adopted** and this doc becomes the canonical reference.
+
+## Why
+
+The current `DictionaryEntry` model assumes one word, one POS, one shared set
+of translations across the whole entry. That breaks against real bilingual
+data:
+
+- "bank" (financial) and "bank" (river) share `(text, POS)` so their
+  translation sets collapse into one — the corpus already keeps senses, the
+  app discards them on materialization.
+- "to take a shower" ↔ "принять душ", "look up" ↔ "искать",
+  "забронировать" ↔ "to book in advance" have no clean home in a
+  single-word, single-POS row.
+- "run" → бежать / управлять / работать / течь needs a per-sense
+  primary-translation order. `wordfreq_rankings` was imported (#96) for
+  exactly this, but there is no app-side column to store the rank.
+- Bulk-loading the base dictionary from a corpus needs a quality gate
+  (heuristic + AI + manual review) before content becomes public, but
+  there is nowhere to stage candidate rows pending review.
+
+This ADR resolves all four problems together because separating them
+produces incompatible intermediate schemas.
+
+## Decisions
+
+### 1. Senses
+
+Translations move off `DictionaryEntry` and onto a new `Sense` child.
+
+**Convention (not schema-enforced):** Senses live on **base entries** —
+rows where `BaseEntryId IS NULL`. Derived forms (inflections) inherit
+senses through their base. The study engine already enforces this
+indirectly by selecting only base entries for the studyable pool, so a
+derived form never needs its own senses queried directly. We do not add
+a CHECK constraint — the cost outweighs the marginal correctness gain.
+
+**Sense identity is per-entry.** A Sense belongs to exactly one
+DictionaryEntry (`Sense.DictionaryEntryId` is a single FK). Two
+synonymous English words ("couch" and "sofa") get independent Sense
+rows even when their glosses overlap; this mirrors how source
+dictionaries (Wiktionary etc.) emit data and avoids a fragile
+cross-entry sense merge step at import time. Synonym deduplication, if
+ever needed, is an additive future concept (`SenseSynonymGroup` or
+similar) — not in scope here.
+
+```
+Sense
+  Id              Guid (v7)
+  DictionaryEntryId  Guid -> DictionaryEntry.Id
+  SenseIndex      int      -- 0-based stable order within the entry
+  Gloss           string   -- short definition in the entry's own language
+  Translations    M2M -> Sense (cross-language, sense-scoped)
+  CreatedAtUtc    timestamptz
+  UpdatedAtUtc    timestamptz
+
+unique (DictionaryEntryId, SenseIndex)
+```
+
+Rationale: matches the corpus shape (`wiktionary_senses` is the source of
+truth for sense splits), gives the study engine a place to attach
+sense-specific contexts and translations, and lets the UI ask the user
+"which meaning?" when adding ambiguous words.
+
+`DictionaryEntry.Translations` (existing M2M) is **dropped**. All
+cross-language linking goes through `Sense.Translations`.
+
+### 2. Phrases and idioms via permissive POS
+
+Multi-word units are stored as ordinary `DictionaryEntry` rows. `Text` is
+already 300 chars wide; the only change is a relaxed `PartOfSpeech`
+vocabulary that adds:
+
+- `phrase` — neutral multi-word unit (e.g. "look up", "take a shower")
+- `idiom` — figurative fixed expression
+- `expression` — catch-all for anything that doesn't fit a single-word POS
+
+POS stays a `string` (no enum), so this is purely a vocabulary update on
+the materialization side and a small relaxation in any code that assumed a
+fixed word-class list. The corpus emits matching POS values from
+Wiktionary directly (`phrase`, `proverb`, `idiom`).
+
+Why not a separate `Expression` entity: it would duplicate Sense,
+Translation, Context, and UserProgress structures for negligible gain.
+The study engine treats phrases identically to single words — cloze on a
+form, grade against expected text. A dedicated entity earns its weight
+only if phrase study diverges meaningfully, which it does not in the
+foreseeable scope.
+
+### 3. Translation ranking
+
+`Sense.Translations` is a many-to-many; the join row carries a rank.
+
+```
+sense_translations
+  source_sense_id  Guid
+  target_sense_id  Guid
+  rank             int       -- 0-based; lower wins for "primary translation"
+  source           text      -- enum: 'wiktionary', 'manual', 'import'
+
+primary key (source_sense_id, target_sense_id)
+```
+
+Rank is seeded from `wordfreq_rankings` at materialization time: the
+target lemma's frequency rank in its language determines order among
+candidate translations of the same source sense. Manually entered
+translations get rank 0 by default (user intent wins over corpus
+frequency).
+
+### 4. Provenance
+
+Provenance lives on the **staging row** that records the approval — not
+on the canonical tables. Once content is promoted, it's verified content;
+the audit trail (who/what/when produced this) is reachable via
+`StagingEntry.PromotedEntryId`.
+
+```
+StagingEntry.Source : enum  ('wiktionary', 'manual', 'import', 'user-suggest')
+                            -- pipeline routing identifier; part of the row's identity
+```
+
+`DictionaryEntry`, `Sense`, and `SenseTranslation` deliberately do **not**
+carry `Source`. Reasoning:
+
+- `DictionaryEntry` is a `(text, language, POS)` dedup key — multiple
+  senses from multiple sources can attach to it, so an entry-level
+  `Source` would be either duplicative or ambiguous.
+- `Sense.Source` and `SenseTranslation.Source` would duplicate
+  information already captured by the staging row that produced the
+  promotion. After approval, the content is canonical — provenance
+  matters for the *decision history*, not the *current state*.
+- For "selectively re-import refreshed Wiktionary data": the bulk
+  pipeline re-stages incoming rows. Dedup against canonical rows happens
+  via `(Source, SourceRefId)` on the staging side, not by reading
+  provenance off canonical rows.
+
+Future flexibility: if a concrete need shows up (e.g. form-level
+provenance for selective inflection refresh), add a *nullable* `Source`
+column at that point. Don't speculate.
+
+### 5. Staging tables
+
+Raw imports do **not** write directly into `DictionaryEntry`. They land
+in a staging table inside `langoose_app` and pass through quality gates
+before promotion.
+
+```
+staging_entries
+  Id              Guid (v7)
+  Source          enum   ('wiktionary', 'wordfreq', 'csv-import', 'user-suggest')
+  SourceRefId     text   -- e.g. corpus row id, csv row #, originating user id
+  Language        text
+  Text            text
+  PartOfSpeech    text
+  Payload         jsonb  -- the full source-shape blob (senses, translations, forms, …)
+  Status          enum   (see below)
+  StatusReason    text   -- optional, why the row landed in its current status
+  AiConfidence    real   -- nullable, set by the AI validation step
+  AiReasoning     text   -- nullable, set by the AI validation step
+  ReviewedByUserId Guid  -- nullable, set on manual approve/reject
+  ReviewedAtUtc   timestamptz
+  PromotedEntryId Guid   -- nullable, set when row promotes to DictionaryEntry
+  CreatedAtUtc    timestamptz
+  UpdatedAtUtc    timestamptz
+
+index (Status)
+index (Source, Status)
+```
+
+`Payload` is the **bundle shape** for one candidate dictionary entry —
+the entry header plus all of its senses and their cross-language
+translations. The reviewer approves or rejects the whole bundle as a
+unit; the promotion job parses the payload and creates
+`DictionaryEntry + Sense[] + SenseTranslation[]` atomically.
+
+```jsonc
+// staging_entries.payload (jsonb)
+{
+  "entry": { "language": "en", "text": "bank", "pos": "noun", "grammar_label": null },
+  "senses": [
+    {
+      "sense_index": 0,
+      "gloss": "a financial institution",
+      "translations": [
+        { "language": "ru", "text": "банк", "pos": "noun", "rank": 0 }
+      ]
+    },
+    {
+      "sense_index": 1,
+      "gloss": "the land alongside a river",
+      "translations": [
+        { "language": "ru", "text": "берег", "pos": "noun", "rank": 0 }
+      ]
+    }
+  ],
+  "raw": { /* original source row, preserved for re-runs */ }
+}
+```
+
+Why bundle, not separate `staging_senses` / `staging_sense_translations`
+tables: source dictionaries (Wiktionary especially) emit senses nested
+under their entry; reviewers think about a word's meanings together;
+splitting the staging schema would force the reviewer to manage
+cross-table relationships during review for no real gain.
+
+`raw` keeps the source row so a re-run of any pipeline stage can
+reconsult the original without going back to the corpus DB.
+
+#### Status enum
+
+```
+Imported            -- just landed from the source, not yet inspected
+HeuristicAccepted   -- passed cleanup filter, ready for AI validation
+HeuristicRejected   -- terminal: filter rejected (numeric, special chars, …)
+AiAccepted          -- AI batch said this looks good
+AiRejected          -- terminal: AI batch flagged as bad
+Approved            -- manual reviewer approved
+Rejected            -- terminal: manual reviewer rejected
+Promoted            -- terminal: row written to DictionaryEntry/Sense, FK in PromotedEntryId
+```
+
+Forward transitions only. A rejected row stays rejected — re-import
+creates a new row. This keeps the audit trail clean.
+
+## Two flows that share the corpus
+
+### Bulk-seed flow (the new pipeline)
+
+```
+corpus.wiktionary_entries  ┐
+corpus.wordfreq_rankings   ┘  →  app.staging_entries (Imported)
+                                       │
+                              [heuristic filter]
+                                       ├→ HeuristicAccepted
+                                       └→ HeuristicRejected (terminal)
+                                       │
+                              [AI batch validation]
+                                       ├→ AiAccepted
+                                       └→ AiRejected (terminal)
+                                       │
+                              [manual review]
+                                       ├→ Approved
+                                       └→ Rejected (terminal)
+                                       │
+                              [promotion job]
+                                       ↓
+                          app.dictionary_entries (IsPublic=true)
+                          app.senses
+                          app.sense_translations
+```
+
+### User-add flow (existing, lightly adapted)
+
+User adds a custom word → `UserDictionaryEntry` (Pending, visible to the
+user with status) → enrichment worker looks up the corpus / canonical
+tables for an existing public Sense matching the user's term + POS.
+
+- **Match found.** Link `UserDictionaryEntry.SourceEntry` (and
+  `TargetEntry`) to the existing public `DictionaryEntry`. Status
+  advances to `Enriched`. The user can study it.
+- **No match.** Status transitions to a terminal Invalid* status
+  (`InvalidSource` / `InvalidLink` / `ProviderError`). The user sees the
+  entry in their dictionary list with a status badge but cannot study
+  it.
+
+**Validation is required**, not optional:
+
+- Pending / Invalid* user entries are visible in the user's list but
+  excluded from the study pool. Only `Enriched` entries become
+  studyable.
+- The corpus is treated as already vetted; presence in the corpus is
+  acceptance. The user-add path does **not** go through the bulk-seed
+  pipeline's AI batch + manual review.
+- Terms not present anywhere are not silently accepted.
+
+**Senses are public-only in MVP.** Users do not have a private sense
+schema. If their term has no public sense:
+
+- For now: the entry stays in a terminal Invalid* status.
+- Later (out of scope here): an auto-staging path can create a
+  `StagingEntry { Source = 'user-suggest', Payload = {...} }` that joins
+  the bulk-seed review queue. Once promoted, the user's entry can be
+  retried and linked.
+
+Why no private senses: a parallel schema (`UserSense`,
+`UserSenseTranslation`) doubles the model for marginal MVP value.
+Defer until users actually hit the gap and complain.
+
+## Pipeline stage details
+
+### Heuristic filter
+
+Runs inline at import. Cheap, deterministic, no external calls.
+
+Rejects entries that:
+
+- Contain digits or non-letter symbols beyond apostrophe / hyphen / space
+- Fall outside length bounds (1 < len ≤ 300, configurable)
+- Have POS in a hard blocklist (`name` / proper noun, `abbrev`, `symbol`)
+- Already exist in `DictionaryEntry` with the same `(Language, Text, PartOfSpeech)`
+  → not technically a reject, just skipped from staging
+
+Accepted rows land as `HeuristicAccepted`. Tunable via configuration so
+the allow-list can change without re-importing.
+
+### AI batch validation
+
+Worker job that picks `HeuristicAccepted` rows in batches and calls the
+Anthropic API in batch mode (50% off) with prompt caching on the
+instruction prefix (the schema, the rubric, the examples are static).
+
+The model decides:
+- Is this a real word/phrase in the source language?
+- Does each sense gloss read coherently?
+- For each candidate translation in `Payload.translations[]`: does it
+  look like a plausible meaning of the source sense?
+- Should this entry be marked an idiom or phrase rather than a base POS?
+
+Output per row: a verdict (`accept` / `reject`), confidence ∈ [0,1], and
+short reasoning. Stored in `AiConfidence` / `AiReasoning`. Verdict
+advances the status to `AiAccepted` or `AiRejected`.
+
+Vendor-neutral interface (`IStagingValidator`) so a future swap to
+another provider — or to a heuristic fallback — is mechanical.
+
+### Manual review and promotion
+
+A small CLI (initially) lists `AiAccepted` rows, optionally filtered by
+language / POS / confidence. The reviewer can:
+
+- Approve → status `Approved`, queued for promotion
+- Reject → status `Rejected`, terminal
+- Edit-and-approve → mutate `Text` / `Payload` then approve
+
+The promotion job reads `Approved` rows, writes `DictionaryEntry` +
+`Sense` + `sense_translations`, sets `PromotedEntryId`, marks the
+staging row `Promoted`. Promotion is idempotent on `(Source, SourceRefId)`.
+
+A web UI for review is out of scope for this ADR; the CLI is enough to
+run the initial seed. #65 (admin tooling) can pick up the UI later.
+
+## Migration path
+
+The existing `DictionaryEntry` table holds ~10 seeded entries. Three
+viable strategies:
+
+1. **Drop and re-seed.** Acceptable because the seed is small and
+   replaceable. Cleanest schema. Loses no production user data
+   (UserDictionaryEntry is empty in practice for early users).
+2. **Backfill senses 1:1.** Each existing `DictionaryEntry` gets one
+   `Sense` row with `SenseIndex=0` and the existing translations move
+   into `sense_translations`. Then drop the entry-level translation join.
+3. **Keep the old `dictionary_entries_translations` join in parallel
+   for a release.** Higher complexity, no real upside given the data
+   volume.
+
+Recommended: **(1) drop and re-seed**. The seed loader is replaced by
+the new bulk pipeline anyway. The migration is a single EF migration
+that adds tables and drops the old translation join.
+
+## Out of scope for this ADR
+
+- The shape of the AI validation prompt — that's an implementation
+  decision in the AI batch validation issue.
+- Web admin UI for review — tracked separately under #65.
+- Real-time enrichment for user adds — `UserDictionaryEntry` keeps its
+  current async lifecycle.
+- Per-user crowdsourcing of public entries — possible later via
+  `Source = 'user-suggest'`, not in this scope.
+- Sense disambiguation in the study engine UI (asking the user "which
+  meaning?") — that's a product feature on top of the schema, tracked
+  separately.
+
+## Implementation issues
+
+The ADR is the spec; the work splits as:
+
+- **#94** — Schema implementation (this doc → migrations + entities).
+- **#57 child A** — Bulk import from corpus into staging with heuristic filter.
+- **#57 child B** — AI batch validation pass.
+- **#57 child C** — Admin review CLI + promotion job.
+- **#57 child D** — Initial bulk seed run, ship the resulting dump.
+- **#91** — Context generation, after schema lands.

--- a/docs/agent/dictionary-schema-design.md
+++ b/docs/agent/dictionary-schema-design.md
@@ -120,7 +120,7 @@ the audit trail (who/what/when produced this) is reachable via
 `StagingEntry.PromotedEntryId`.
 
 ```
-StagingEntry.Source : enum  ('wiktionary', 'manual', 'import', 'user-suggest')
+StagingEntry.Source : enum EntrySource (Wiktionary, Manual, Import, UserSuggest)
                             -- pipeline routing identifier; part of the row's identity
 ```
 
@@ -292,7 +292,7 @@ schema. If their term has no public sense:
 
 - For now: the entry stays in a terminal Invalid* status.
 - Later (out of scope here): an auto-staging path can create a
-  `StagingEntry { Source = 'user-suggest', Payload = {...} }` that joins
+  `StagingEntry { Source = UserSuggest, Payload = {...} }` that joins
   the bulk-seed review queue. Once promoted, the user's entry can be
   retried and linked.
 
@@ -380,7 +380,7 @@ that adds tables and drops the old translation join.
 - Real-time enrichment for user adds — `UserDictionaryEntry` keeps its
   current async lifecycle.
 - Per-user crowdsourcing of public entries — possible later via
-  `Source = 'user-suggest'`, not in this scope.
+  `Source = UserSuggest`, not in this scope.
 - Sense disambiguation in the study engine UI (asking the user "which
   meaning?") — that's a product feature on top of the schema, tracked
   separately.

--- a/docs/agent/efcore-structure.md
+++ b/docs/agent/efcore-structure.md
@@ -11,7 +11,7 @@ better for B-tree indexing in PostgreSQL). Mapping tables use composite primary 
 |--------|-------|-------------------|
 | DictionaryEntry | dictionary_entries | Self-ref BaseEntryId, has many EntryContexts, has many Senses |
 | Sense | senses | FK -> DictionaryEntry, has many SenseTranslations. Unique (DictionaryEntryId, SenseIndex) |
-| SenseTranslation | sense_translations | Composite PK (SourceSenseId, TargetSenseId). Carries Rank, Source |
+| SenseTranslation | sense_translations | Composite PK (SourceSenseId, TargetSenseId). Carries Rank |
 | EntryContext | entry_contexts | FK -> DictionaryEntry, M2M Translations |
 | UserDictionaryEntry | user_dictionary_entries | FK SourceEntryId -> DictionaryEntry, FK TargetEntryId -> DictionaryEntry (both nullable) |
 | UserEntryContext | user_entry_contexts | FK -> UserDictionaryEntry |
@@ -36,9 +36,9 @@ Contains `AuthUser`, `AuthSession`, and OpenIddict tables. Unchanged by domain r
 - PostgreSQL arrays (`text[]`) for `List<string>` properties (Tags, etc.).
 - Use implicit many-to-many via `HasMany().WithMany().UsingEntity()` when the
   join carries no extra data (e.g. `EntryContext.Translations`). When the join
-  needs columns of its own (rank, source, audit fields), define an explicit
-  join entity class — `SenseTranslation` is the canonical example (composite
-  PK on `(SourceSenseId, TargetSenseId)`, carries `Rank` and `Source`).
+  needs columns of its own (rank, audit fields), define an explicit join
+  entity class — `SenseTranslation` is the canonical example (composite PK on
+  `(SourceSenseId, TargetSenseId)`, carries `Rank`).
 - Services use `AppDbContext` directly — no repository-per-entity abstraction.
 - Keep EF-specific concerns out of controllers.
 

--- a/docs/agent/efcore-structure.md
+++ b/docs/agent/efcore-structure.md
@@ -9,7 +9,9 @@ better for B-tree indexing in PostgreSQL). Mapping tables use composite primary 
 
 | Entity | Table | Key Relationships |
 |--------|-------|-------------------|
-| DictionaryEntry | dictionary_entries | Self-ref BaseEntryId, has many EntryContexts, M2M Translations |
+| DictionaryEntry | dictionary_entries | Self-ref BaseEntryId, has many EntryContexts, has many Senses |
+| Sense | senses | FK -> DictionaryEntry, has many SenseTranslations. Unique (DictionaryEntryId, SenseIndex) |
+| SenseTranslation | sense_translations | Composite PK (SourceSenseId, TargetSenseId). Carries Rank, Source |
 | EntryContext | entry_contexts | FK -> DictionaryEntry, M2M Translations |
 | UserDictionaryEntry | user_dictionary_entries | FK SourceEntryId -> DictionaryEntry, FK TargetEntryId -> DictionaryEntry (both nullable) |
 | UserEntryContext | user_entry_contexts | FK -> UserDictionaryEntry |
@@ -17,6 +19,7 @@ better for B-tree indexing in PostgreSQL). Mapping tables use composite primary 
 | StudyEvent | study_events | FK -> DictionaryEntry, FK -> EntryContext (nullable) |
 | ContentFlag | content_flags | FK -> DictionaryEntry |
 | ImportRecord | import_records | No FKs to content tables |
+| StagingEntry | staging_entries | Pre-promotion holding table for the bulk-seed pipeline. JSONB Payload, status enum, AI fields, optional PromotedEntryId. See dictionary-schema-design.md |
 
 ### Auth Database (AuthDbContext)
 
@@ -31,19 +34,25 @@ Contains `AuthUser`, `AuthSession`, and OpenIddict tables. Unchanged by domain r
 - Use `ApplyConfigurationsFromAssembly` in `AppDbContext.OnModelCreating`.
 - Enum fields stored as strings via `HasConversion<string>()`.
 - PostgreSQL arrays (`text[]`) for `List<string>` properties (Tags, etc.).
-- Implicit many-to-many via `HasMany().WithMany().UsingEntity()` for translation
-  links. No explicit join entity classes — EF manages the join tables.
+- Use implicit many-to-many via `HasMany().WithMany().UsingEntity()` when the
+  join carries no extra data (e.g. `EntryContext.Translations`). When the join
+  needs columns of its own (rank, source, audit fields), define an explicit
+  join entity class — `SenseTranslation` is the canonical example (composite
+  PK on `(SourceSenseId, TargetSenseId)`, carries `Rank` and `Source`).
 - Services use `AppDbContext` directly — no repository-per-entity abstraction.
 - Keep EF-specific concerns out of controllers.
 
 ## Key Indexes
 
 - `DictionaryEntry`: index on `(Language, Text, PartOfSpeech)`, index on `BaseEntryId`.
+- `Sense`: unique on `(DictionaryEntryId, SenseIndex)`.
+- `SenseTranslation`: composite PK `(SourceSenseId, TargetSenseId)` covers source-leading lookups; explicit index on `TargetSenseId` for the reverse FK and cascade-delete path.
 - `EntryContext`: index on `DictionaryEntryId`.
 - `UserDictionaryEntry`: index on `UserId`,
   index on `(EnrichmentStatus, CreatedAtUtc)` for worker polling.
 - `UserProgress`: unique on `(UserId, DictionaryEntryId)`.
 - `StudyEvent`: index on `(UserId, CreatedAtUtc)` for dashboard queries.
+- `StagingEntry`: index on `Status` (worker polling), `(Source, SourceRefId)` (dedup at import; not unique — application enforces no-duplicate-insert).
 
 ## Migrations
 
@@ -57,8 +66,13 @@ Contains `AuthUser`, `AuthSession`, and OpenIddict tables. Unchanged by domain r
 
 - `DatabaseSeeder` and `SeedDataLoader` in `Data/Seeding/`.
 - `base-store.json` contains DictionaryEntries (base forms + derived forms)
-  and EntryContexts. Translations use implicit M2M via navigation properties.
+  and EntryContexts. The seeder materializes one default `Sense` per entry
+  (`SenseIndex = 0`) and links cross-language pairs as `SenseTranslation`
+  rows in both directions.
 - Seeding is empty-database-only via `Langoose.DbTool seed-app`.
+- The hardcoded JSON seed is a placeholder that will be replaced by the
+  bulk-seed pipeline (#57) once that pipeline ships. See
+  `dictionary-schema-design.md` for the staged-pipeline design.
 
 ## Review Checklist
 


### PR DESCRIPTION
Closes #94. Implements the schema rework defined in [`docs/agent/dictionary-schema-design.md`](../blob/feat/94-sense-aware-schema/docs/agent/dictionary-schema-design.md). This unblocks #57 (base-dictionary materialization) and the future corpus-backed enrichment provider sub-issue under #92.

## Summary

- New `Sense` entity and `SenseTranslation` join entity (with `Rank`). `DictionaryEntry.Translations` M2M is dropped — translations are now sense-scoped.
- New `staging_entries` table for the bulk-seed pipeline (#57). Bundle-shaped `Payload` (jsonb) holds the candidate entry header + senses + translations for atomic review/promotion.
- `PartOfSpeech` vocabulary relaxed to allow `phrase` / `idiom` / `expression` (no schema change — already a `string` column; this is a documentation + downstream-consumer convention).
- `EnrichmentProcessor` materializes a default `Sense` per new entry and writes `SenseTranslation` rows in both directions.
- `StudyService.GetNextCardAsync` and `DictionaryService.ExportCsvAsync` now read translations through senses.
- ADR added at `docs/agent/dictionary-schema-design.md`. CLAUDE.md/AGENTS.md guidance index and `docs/agent/efcore-structure.md` updated to match.
- Old `InitialFoundation` migration replaced with a fresh one (no production data yet — drop-and-re-seed per the doc).
- `UpdatedAtUtc` is now `required` on every entity that has it. Build was already setting it everywhere; this just enforces it at compile time so future callers can't silently emit `default(DateTimeOffset)`.

## Provenance model (notable design call)

Provenance lives **only on `StagingEntry.Source`**, not on canonical tables. `DictionaryEntry`, `Sense`, and `SenseTranslation` deliberately carry no `Source` column — once content is approved and promoted, it's canonical, and the audit trail is reachable via `StagingEntry.PromotedEntryId`. Discussion captured in the ADR's "Provenance" section.

## Senses are public-only in MVP

User adds that miss the corpus go to a terminal Invalid status (existing `EnrichmentStatus` flow). A future auto-staging path can write `StagingEntry { Source = 'user-suggest' }` to feed the public review queue, but that's deferred — a parallel private-sense schema would double the model for marginal MVP value.

## Test plan

- [x] `dotnet build apps/api/Langoose.sln -p:RestoreConfigFile=apps/api/NuGet.Config` — 0 warnings, 0 errors
- [x] `dotnet test ... Langoose.Core.UnitTests` — 16 passed
- [x] `dotnet test ... Langoose.Api.IntegrationTests` — 25 passed
- [x] Migration regenerated cleanly (single `InitialFoundation` migration; no `dictionary_entries_translations` join table)
- [x] CLAUDE.md and AGENTS.md remain in sync (`scripts/sync-rules.sh status` clean)

Sub-issues created on top of this for the #57 epic:
- [#105](https://github.com/altav1sta/langoose/issues/105) Bulk import to staging with heuristic filter
- [#106](https://github.com/altav1sta/langoose/issues/106) AI batch validation pass
- [#107](https://github.com/altav1sta/langoose/issues/107) Admin review CLI + promotion job
- [#108](https://github.com/altav1sta/langoose/issues/108) Initial bulk seed run + dump publication